### PR TITLE
Make plugin independent of Friends plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Friends Send to E-Reader
+# Send to E-Reader
 
 Send new articles directly to your e-reader via e-mail or download the ePub.
 
@@ -13,7 +13,7 @@ Send new articles directly to your e-reader via e-mail or download the ePub.
 
 See the post [Subscribing to RSS Feeds on your E-Reader using your own WordPress blog](https://wpfriends.at/2021/09/20/subscribing-to-rss-feeds-on-your-e-reader/) for more details on how it works.
 
-This plugin is meant to be used with the [Friends plugin](https://github.com/akirk/friends/).
+This plugin works standalone or integrates with the [Friends plugin](https://github.com/akirk/friends/).
 
 ## Changelog
 
@@ -60,9 +60,9 @@ This plugin is meant to be used with the [Friends plugin](https://github.com/aki
 - Allow downloading the ePub.
 - Theoretically add support for Tolino. Not functional because Thalia doesn't want to provide OAuth2 credentials.
 
-[#12]: https://github.com/akirk/friends-send-to-e-reader/pull/12
-[#11]: https://github.com/akirk/friends-send-to-e-reader/pull/11
-[#9]: https://github.com/akirk/friends-send-to-e-reader/pull/9
-[#7]: https://github.com/akirk/friends-send-to-e-reader/pull/7
-[#6]: https://github.com/akirk/friends-send-to-e-reader/pull/6
-[#5]: https://github.com/akirk/friends-send-to-e-reader/pull/5
+[#12]: https://github.com/akirk/send-to-e-reader/pull/12
+[#11]: https://github.com/akirk/send-to-e-reader/pull/11
+[#9]: https://github.com/akirk/send-to-e-reader/pull/9
+[#7]: https://github.com/akirk/send-to-e-reader/pull/7
+[#6]: https://github.com/akirk/send-to-e-reader/pull/6
+[#5]: https://github.com/akirk/send-to-e-reader/pull/5

--- a/composer.json
+++ b/composer.json
@@ -4,6 +4,7 @@
         "dealerdirect/phpcodesniffer-composer-installer": "*",
         "object-calisthenics/phpcs-calisthenics-rules": "*",
         "phpcompatibility/php-compatibility": "*",
+        "phpunit/phpunit": "^9.0",
         "wp-coding-standards/wpcs": "*",
         "yoast/phpunit-polyfills": "*"
     },

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "akirk/friends-send-to-e-reader",
+    "name": "akirk/send-to-e-reader",
     "require-dev": {
         "dealerdirect/phpcodesniffer-composer-installer": "*",
         "object-calisthenics/phpcs-calisthenics-rules": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fc7869325d7bab0359c4a25d16d1f1d7",
+    "content-hash": "9ae5cc11a5f48807e544a28a7a2e270a",
     "packages": [],
     "packages-dev": [
         {
@@ -84,30 +84,30 @@
         },
         {
             "name": "doctrine/instantiator",
-            "version": "1.4.1",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "10dcfce151b967d20fde1b34ae6640712c3891bc"
+                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/10dcfce151b967d20fde1b34ae6640712c3891bc",
-                "reference": "10dcfce151b967d20fde1b34ae6640712c3891bc",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
+                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1 || ^8.0"
+                "php": "^8.1"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^9",
+                "doctrine/coding-standard": "^11",
                 "ext-pdo": "*",
                 "ext-phar": "*",
-                "phpbench/phpbench": "^0.16 || ^1",
-                "phpstan/phpstan": "^1.4",
-                "phpstan/phpstan-phpunit": "^1",
-                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
-                "vimeo/psalm": "^4.22"
+                "phpbench/phpbench": "^1.2",
+                "phpstan/phpstan": "^1.9.4",
+                "phpstan/phpstan-phpunit": "^1.3",
+                "phpunit/phpunit": "^9.5.27",
+                "vimeo/psalm": "^5.4"
             },
             "type": "library",
             "autoload": {
@@ -134,7 +134,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/instantiator/issues",
-                "source": "https://github.com/doctrine/instantiator/tree/1.4.1"
+                "source": "https://github.com/doctrine/instantiator/tree/2.0.0"
             },
             "funding": [
                 {
@@ -150,20 +150,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-03-03T08:28:38+00:00"
+            "time": "2022-12-30T00:23:10+00:00"
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.11.0",
+            "version": "1.13.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "14daed4296fae74d9e3201d2c4925d1acb7aa614"
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/14daed4296fae74d9e3201d2c4925d1acb7aa614",
-                "reference": "14daed4296fae74d9e3201d2c4925d1acb7aa614",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a",
                 "shasum": ""
             },
             "require": {
@@ -171,11 +171,12 @@
             },
             "conflict": {
                 "doctrine/collections": "<1.6.8",
-                "doctrine/common": "<2.13.3 || >=3,<3.2.2"
+                "doctrine/common": "<2.13.3 || >=3 <3.2.2"
             },
             "require-dev": {
                 "doctrine/collections": "^1.6.8",
                 "doctrine/common": "^2.13.3 || ^3.2.2",
+                "phpspec/prophecy": "^1.10",
                 "phpunit/phpunit": "^7.5.20 || ^8.5.23 || ^9.5.13"
             },
             "type": "library",
@@ -201,7 +202,7 @@
             ],
             "support": {
                 "issues": "https://github.com/myclabs/DeepCopy/issues",
-                "source": "https://github.com/myclabs/DeepCopy/tree/1.11.0"
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.4"
             },
             "funding": [
                 {
@@ -209,31 +210,28 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-03-03T13:19:32+00:00"
+            "time": "2025-08-01T08:46:24+00:00"
         },
         {
             "name": "nette/utils",
-            "version": "v3.2.8",
+            "version": "v3.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nette/utils.git",
-                "reference": "02a54c4c872b99e4ec05c4aec54b5a06eb0f6368"
+                "reference": "2c8d1628317fddc692d90fd7732e3dd98327dbf0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nette/utils/zipball/02a54c4c872b99e4ec05c4aec54b5a06eb0f6368",
-                "reference": "02a54c4c872b99e4ec05c4aec54b5a06eb0f6368",
+                "url": "https://api.github.com/repos/nette/utils/zipball/2c8d1628317fddc692d90fd7732e3dd98327dbf0",
+                "reference": "2c8d1628317fddc692d90fd7732e3dd98327dbf0",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2 <8.3"
-            },
-            "conflict": {
-                "nette/di": "<3.0.6"
+                "php": ">=7.1"
             },
             "require-dev": {
                 "nette/tester": "~2.0",
-                "phpstan/phpstan": "^1.0",
+                "phpstan/phpstan": "^0.12",
                 "tracy/tracy": "^2.3"
             },
             "suggest": {
@@ -248,7 +246,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.2-dev"
+                    "dev-master": "3.1-dev"
                 }
             },
             "autoload": {
@@ -292,31 +290,33 @@
             ],
             "support": {
                 "issues": "https://github.com/nette/utils/issues",
-                "source": "https://github.com/nette/utils/tree/v3.2.8"
+                "source": "https://github.com/nette/utils/tree/v3.1.6"
             },
-            "time": "2022-09-12T23:36:20+00:00"
+            "time": "2021-09-20T10:38:05+00:00"
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.15.1",
+            "version": "v5.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "0ef6c55a3f47f89d7a374e6f835197a0b5fcf900"
+                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/0ef6c55a3f47f89d7a374e6f835197a0b5fcf900",
-                "reference": "0ef6c55a3f47f89d7a374e6f835197a0b5fcf900",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/dca41cd15c2ac9d055ad70dbfd011130757d1f82",
+                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82",
                 "shasum": ""
             },
             "require": {
+                "ext-ctype": "*",
+                "ext-json": "*",
                 "ext-tokenizer": "*",
-                "php": ">=7.0"
+                "php": ">=7.4"
             },
             "require-dev": {
                 "ircmaxell/php-yacc": "^0.0.7",
-                "phpunit/phpunit": "^6.5 || ^7.0 || ^8.0 || ^9.0"
+                "phpunit/phpunit": "^9.0"
             },
             "bin": [
                 "bin/php-parse"
@@ -324,7 +324,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.9-dev"
+                    "dev-master": "5.x-dev"
                 }
             },
             "autoload": {
@@ -348,9 +348,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.15.1"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.7.0"
             },
-            "time": "2022-09-04T07:30:47+00:00"
+            "time": "2025-12-06T11:56:16+00:00"
         },
         {
             "name": "object-calisthenics/phpcs-calisthenics-rules",
@@ -404,20 +404,21 @@
         },
         {
             "name": "phar-io/manifest",
-            "version": "2.0.3",
+            "version": "2.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phar-io/manifest.git",
-                "reference": "97803eca37d319dfa7826cc2437fc020857acb53"
+                "reference": "54750ef60c58e43759730615a392c31c80e23176"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/manifest/zipball/97803eca37d319dfa7826cc2437fc020857acb53",
-                "reference": "97803eca37d319dfa7826cc2437fc020857acb53",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/54750ef60c58e43759730615a392c31c80e23176",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
+                "ext-libxml": "*",
                 "ext-phar": "*",
                 "ext-xmlwriter": "*",
                 "phar-io/version": "^3.0.1",
@@ -458,9 +459,15 @@
             "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
             "support": {
                 "issues": "https://github.com/phar-io/manifest/issues",
-                "source": "https://github.com/phar-io/manifest/tree/2.0.3"
+                "source": "https://github.com/phar-io/manifest/tree/2.0.4"
             },
-            "time": "2021-07-20T11:28:43+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-03T12:33:53+00:00"
         },
         {
             "name": "phar-io/version",
@@ -576,6 +583,181 @@
             "time": "2019-12-27T09:44:58+00:00"
         },
         {
+            "name": "phpcsstandards/phpcsextra",
+            "version": "1.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/PHPCSExtra.git",
+                "reference": "b598aa890815b8df16363271b659d73280129101"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSExtra/zipball/b598aa890815b8df16363271b659d73280129101",
+                "reference": "b598aa890815b8df16363271b659d73280129101",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4",
+                "phpcsstandards/phpcsutils": "^1.2.0",
+                "squizlabs/php_codesniffer": "^3.13.5 || ^4.0.1"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-console-highlighter": "^1.0",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
+                "phpcsstandards/phpcsdevcs": "^1.2.0",
+                "phpcsstandards/phpcsdevtools": "^1.2.1",
+                "phpunit/phpunit": "^4.5 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.3.4"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-stable": "1.x-dev",
+                    "dev-develop": "1.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
+                    "role": "lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHPCSExtra/graphs/contributors"
+                }
+            ],
+            "description": "A collection of sniffs and standards for use with PHP_CodeSniffer.",
+            "keywords": [
+                "PHP_CodeSniffer",
+                "phpcbf",
+                "phpcodesniffer-standard",
+                "phpcs",
+                "standards",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCSStandards/PHPCSExtra/issues",
+                "security": "https://github.com/PHPCSStandards/PHPCSExtra/security/policy",
+                "source": "https://github.com/PHPCSStandards/PHPCSExtra"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2025-11-12T23:06:57+00:00"
+        },
+        {
+            "name": "phpcsstandards/phpcsutils",
+            "version": "1.2.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/PHPCSUtils.git",
+                "reference": "c216317e96c8b3f5932808f9b0f1f7a14e3bbf55"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/c216317e96c8b3f5932808f9b0f1f7a14e3bbf55",
+                "reference": "c216317e96c8b3f5932808f9b0f1f7a14e3bbf55",
+                "shasum": ""
+            },
+            "require": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7 || ^1.0",
+                "php": ">=5.4",
+                "squizlabs/php_codesniffer": "^3.13.5 || ^4.0.1"
+            },
+            "require-dev": {
+                "ext-filter": "*",
+                "php-parallel-lint/php-console-highlighter": "^1.0",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
+                "phpcsstandards/phpcsdevcs": "^1.2.0",
+                "yoast/phpunit-polyfills": "^1.1.0 || ^2.0.0 || ^3.0.0"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-stable": "1.x-dev",
+                    "dev-develop": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "PHPCSUtils/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
+                    "role": "lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHPCSUtils/graphs/contributors"
+                }
+            ],
+            "description": "A suite of utility functions for use with PHP_CodeSniffer",
+            "homepage": "https://phpcsutils.com/",
+            "keywords": [
+                "PHP_CodeSniffer",
+                "phpcbf",
+                "phpcodesniffer-standard",
+                "phpcs",
+                "phpcs3",
+                "phpcs4",
+                "standards",
+                "static analysis",
+                "tokens",
+                "utility"
+            ],
+            "support": {
+                "docs": "https://phpcsutils.com/",
+                "issues": "https://github.com/PHPCSStandards/PHPCSUtils/issues",
+                "security": "https://github.com/PHPCSStandards/PHPCSUtils/security/policy",
+                "source": "https://github.com/PHPCSStandards/PHPCSUtils"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2025-12-08T14:27:58+00:00"
+        },
+        {
             "name": "phpstan/phpdoc-parser",
             "version": "0.4.9",
             "source": {
@@ -630,44 +812,44 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "9.2.17",
+            "version": "9.2.32",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "aa94dc41e8661fe90c7316849907cba3007b10d8"
+                "reference": "85402a822d1ecf1db1096959413d35e1c37cf1a5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/aa94dc41e8661fe90c7316849907cba3007b10d8",
-                "reference": "aa94dc41e8661fe90c7316849907cba3007b10d8",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/85402a822d1ecf1db1096959413d35e1c37cf1a5",
+                "reference": "85402a822d1ecf1db1096959413d35e1c37cf1a5",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-libxml": "*",
                 "ext-xmlwriter": "*",
-                "nikic/php-parser": "^4.14",
+                "nikic/php-parser": "^4.19.1 || ^5.1.0",
                 "php": ">=7.3",
-                "phpunit/php-file-iterator": "^3.0.3",
-                "phpunit/php-text-template": "^2.0.2",
-                "sebastian/code-unit-reverse-lookup": "^2.0.2",
-                "sebastian/complexity": "^2.0",
-                "sebastian/environment": "^5.1.2",
-                "sebastian/lines-of-code": "^1.0.3",
-                "sebastian/version": "^3.0.1",
-                "theseer/tokenizer": "^1.2.0"
+                "phpunit/php-file-iterator": "^3.0.6",
+                "phpunit/php-text-template": "^2.0.4",
+                "sebastian/code-unit-reverse-lookup": "^2.0.3",
+                "sebastian/complexity": "^2.0.3",
+                "sebastian/environment": "^5.1.5",
+                "sebastian/lines-of-code": "^1.0.4",
+                "sebastian/version": "^3.0.2",
+                "theseer/tokenizer": "^1.2.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^9.6"
             },
             "suggest": {
-                "ext-pcov": "*",
-                "ext-xdebug": "*"
+                "ext-pcov": "PHP extension that provides line coverage",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "9.2-dev"
+                    "dev-main": "9.2.x-dev"
                 }
             },
             "autoload": {
@@ -695,7 +877,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.17"
+                "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.32"
             },
             "funding": [
                 {
@@ -703,7 +886,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-08-30T12:24:04+00:00"
+            "time": "2024-08-22T04:23:01+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -948,50 +1131,50 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.5.25",
+            "version": "9.6.31",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "3e6f90ca7e3d02025b1d147bd8d4a89fd4ca8a1d"
+                "reference": "945d0b7f346a084ce5549e95289962972c4272e5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/3e6f90ca7e3d02025b1d147bd8d4a89fd4ca8a1d",
-                "reference": "3e6f90ca7e3d02025b1d147bd8d4a89fd4ca8a1d",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/945d0b7f346a084ce5549e95289962972c4272e5",
+                "reference": "945d0b7f346a084ce5549e95289962972c4272e5",
                 "shasum": ""
             },
             "require": {
-                "doctrine/instantiator": "^1.3.1",
+                "doctrine/instantiator": "^1.5.0 || ^2",
                 "ext-dom": "*",
                 "ext-json": "*",
                 "ext-libxml": "*",
                 "ext-mbstring": "*",
                 "ext-xml": "*",
                 "ext-xmlwriter": "*",
-                "myclabs/deep-copy": "^1.10.1",
-                "phar-io/manifest": "^2.0.3",
-                "phar-io/version": "^3.0.2",
+                "myclabs/deep-copy": "^1.13.4",
+                "phar-io/manifest": "^2.0.4",
+                "phar-io/version": "^3.2.1",
                 "php": ">=7.3",
-                "phpunit/php-code-coverage": "^9.2.13",
-                "phpunit/php-file-iterator": "^3.0.5",
+                "phpunit/php-code-coverage": "^9.2.32",
+                "phpunit/php-file-iterator": "^3.0.6",
                 "phpunit/php-invoker": "^3.1.1",
-                "phpunit/php-text-template": "^2.0.3",
-                "phpunit/php-timer": "^5.0.2",
-                "sebastian/cli-parser": "^1.0.1",
-                "sebastian/code-unit": "^1.0.6",
-                "sebastian/comparator": "^4.0.8",
-                "sebastian/diff": "^4.0.3",
-                "sebastian/environment": "^5.1.3",
-                "sebastian/exporter": "^4.0.5",
-                "sebastian/global-state": "^5.0.1",
-                "sebastian/object-enumerator": "^4.0.3",
-                "sebastian/resource-operations": "^3.0.3",
-                "sebastian/type": "^3.2",
+                "phpunit/php-text-template": "^2.0.4",
+                "phpunit/php-timer": "^5.0.3",
+                "sebastian/cli-parser": "^1.0.2",
+                "sebastian/code-unit": "^1.0.8",
+                "sebastian/comparator": "^4.0.9",
+                "sebastian/diff": "^4.0.6",
+                "sebastian/environment": "^5.1.5",
+                "sebastian/exporter": "^4.0.8",
+                "sebastian/global-state": "^5.0.8",
+                "sebastian/object-enumerator": "^4.0.4",
+                "sebastian/resource-operations": "^3.0.4",
+                "sebastian/type": "^3.2.1",
                 "sebastian/version": "^3.0.2"
             },
             "suggest": {
-                "ext-soap": "*",
-                "ext-xdebug": "*"
+                "ext-soap": "To be able to generate mocks based on WSDL files",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
             },
             "bin": [
                 "phpunit"
@@ -999,7 +1182,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "9.5-dev"
+                    "dev-master": "9.6-dev"
                 }
             },
             "autoload": {
@@ -1030,7 +1213,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.25"
+                "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.31"
             },
             "funding": [
                 {
@@ -1042,24 +1226,32 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/phpunit/phpunit",
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-09-25T03:44:45+00:00"
+            "time": "2025-12-06T07:45:52+00:00"
         },
         {
             "name": "sebastian/cli-parser",
-            "version": "1.0.1",
+            "version": "1.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/cli-parser.git",
-                "reference": "442e7c7e687e42adc03470c7b668bc4b2402c0b2"
+                "reference": "2b56bea83a09de3ac06bb18b92f068e60cc6f50b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/442e7c7e687e42adc03470c7b668bc4b2402c0b2",
-                "reference": "442e7c7e687e42adc03470c7b668bc4b2402c0b2",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/2b56bea83a09de3ac06bb18b92f068e60cc6f50b",
+                "reference": "2b56bea83a09de3ac06bb18b92f068e60cc6f50b",
                 "shasum": ""
             },
             "require": {
@@ -1094,7 +1286,7 @@
             "homepage": "https://github.com/sebastianbergmann/cli-parser",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
-                "source": "https://github.com/sebastianbergmann/cli-parser/tree/1.0.1"
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/1.0.2"
             },
             "funding": [
                 {
@@ -1102,7 +1294,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T06:08:49+00:00"
+            "time": "2024-03-02T06:27:43+00:00"
         },
         {
             "name": "sebastian/code-unit",
@@ -1217,16 +1409,16 @@
         },
         {
             "name": "sebastian/comparator",
-            "version": "4.0.8",
+            "version": "4.0.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "fa0f136dd2334583309d32b62544682ee972b51a"
+                "reference": "67a2df3a62639eab2cc5906065e9805d4fd5dfc5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/fa0f136dd2334583309d32b62544682ee972b51a",
-                "reference": "fa0f136dd2334583309d32b62544682ee972b51a",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/67a2df3a62639eab2cc5906065e9805d4fd5dfc5",
+                "reference": "67a2df3a62639eab2cc5906065e9805d4fd5dfc5",
                 "shasum": ""
             },
             "require": {
@@ -1279,32 +1471,44 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/comparator/issues",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.8"
+                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.9"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/comparator",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2022-09-14T12:41:17+00:00"
+            "time": "2025-08-10T06:51:50+00:00"
         },
         {
             "name": "sebastian/complexity",
-            "version": "2.0.2",
+            "version": "2.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/complexity.git",
-                "reference": "739b35e53379900cc9ac327b2147867b8b6efd88"
+                "reference": "25f207c40d62b8b7aa32f5ab026c53561964053a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/739b35e53379900cc9ac327b2147867b8b6efd88",
-                "reference": "739b35e53379900cc9ac327b2147867b8b6efd88",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/25f207c40d62b8b7aa32f5ab026c53561964053a",
+                "reference": "25f207c40d62b8b7aa32f5ab026c53561964053a",
                 "shasum": ""
             },
             "require": {
-                "nikic/php-parser": "^4.7",
+                "nikic/php-parser": "^4.18 || ^5.0",
                 "php": ">=7.3"
             },
             "require-dev": {
@@ -1336,7 +1540,7 @@
             "homepage": "https://github.com/sebastianbergmann/complexity",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/complexity/issues",
-                "source": "https://github.com/sebastianbergmann/complexity/tree/2.0.2"
+                "source": "https://github.com/sebastianbergmann/complexity/tree/2.0.3"
             },
             "funding": [
                 {
@@ -1344,20 +1548,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T15:52:27+00:00"
+            "time": "2023-12-22T06:19:30+00:00"
         },
         {
             "name": "sebastian/diff",
-            "version": "4.0.4",
+            "version": "4.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "3461e3fccc7cfdfc2720be910d3bd73c69be590d"
+                "reference": "ba01945089c3a293b01ba9badc29ad55b106b0bc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/3461e3fccc7cfdfc2720be910d3bd73c69be590d",
-                "reference": "3461e3fccc7cfdfc2720be910d3bd73c69be590d",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/ba01945089c3a293b01ba9badc29ad55b106b0bc",
+                "reference": "ba01945089c3a293b01ba9badc29ad55b106b0bc",
                 "shasum": ""
             },
             "require": {
@@ -1402,7 +1606,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/diff/issues",
-                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.4"
+                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.6"
             },
             "funding": [
                 {
@@ -1410,20 +1614,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:10:38+00:00"
+            "time": "2024-03-02T06:30:58+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "5.1.4",
+            "version": "5.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "1b5dff7bb151a4db11d49d90e5408e4e938270f7"
+                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/1b5dff7bb151a4db11d49d90e5408e4e938270f7",
-                "reference": "1b5dff7bb151a4db11d49d90e5408e4e938270f7",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
+                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
                 "shasum": ""
             },
             "require": {
@@ -1465,7 +1669,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/environment/issues",
-                "source": "https://github.com/sebastianbergmann/environment/tree/5.1.4"
+                "source": "https://github.com/sebastianbergmann/environment/tree/5.1.5"
             },
             "funding": [
                 {
@@ -1473,20 +1677,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-04-03T09:37:03+00:00"
+            "time": "2023-02-03T06:03:51+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "4.0.5",
+            "version": "4.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "ac230ed27f0f98f597c8a2b6eb7ac563af5e5b9d"
+                "reference": "14c6ba52f95a36c3d27c835d65efc7123c446e8c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/ac230ed27f0f98f597c8a2b6eb7ac563af5e5b9d",
-                "reference": "ac230ed27f0f98f597c8a2b6eb7ac563af5e5b9d",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/14c6ba52f95a36c3d27c835d65efc7123c446e8c",
+                "reference": "14c6ba52f95a36c3d27c835d65efc7123c446e8c",
                 "shasum": ""
             },
             "require": {
@@ -1542,28 +1746,40 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/exporter/issues",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.5"
+                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.8"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/exporter",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2022-09-14T06:03:37+00:00"
+            "time": "2025-09-24T06:03:27+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "5.0.5",
+            "version": "5.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "0ca8db5a5fc9c8646244e629625ac486fa286bf2"
+                "reference": "b6781316bdcd28260904e7cc18ec983d0d2ef4f6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/0ca8db5a5fc9c8646244e629625ac486fa286bf2",
-                "reference": "0ca8db5a5fc9c8646244e629625ac486fa286bf2",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/b6781316bdcd28260904e7cc18ec983d0d2ef4f6",
+                "reference": "b6781316bdcd28260904e7cc18ec983d0d2ef4f6",
                 "shasum": ""
             },
             "require": {
@@ -1606,32 +1822,44 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/global-state/issues",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.5"
+                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.8"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/global-state",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2022-02-14T08:28:10+00:00"
+            "time": "2025-08-10T07:10:35+00:00"
         },
         {
             "name": "sebastian/lines-of-code",
-            "version": "1.0.3",
+            "version": "1.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/lines-of-code.git",
-                "reference": "c1c2e997aa3146983ed888ad08b15470a2e22ecc"
+                "reference": "e1e4a170560925c26d424b6a03aed157e7dcc5c5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/c1c2e997aa3146983ed888ad08b15470a2e22ecc",
-                "reference": "c1c2e997aa3146983ed888ad08b15470a2e22ecc",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/e1e4a170560925c26d424b6a03aed157e7dcc5c5",
+                "reference": "e1e4a170560925c26d424b6a03aed157e7dcc5c5",
                 "shasum": ""
             },
             "require": {
-                "nikic/php-parser": "^4.6",
+                "nikic/php-parser": "^4.18 || ^5.0",
                 "php": ">=7.3"
             },
             "require-dev": {
@@ -1663,7 +1891,7 @@
             "homepage": "https://github.com/sebastianbergmann/lines-of-code",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
-                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/1.0.3"
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/1.0.4"
             },
             "funding": [
                 {
@@ -1671,7 +1899,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-11-28T06:42:11+00:00"
+            "time": "2023-12-22T06:20:34+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
@@ -1787,16 +2015,16 @@
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "4.0.4",
+            "version": "4.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "cd9d8cf3c5804de4341c283ed787f099f5506172"
+                "reference": "539c6691e0623af6dc6f9c20384c120f963465a0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/cd9d8cf3c5804de4341c283ed787f099f5506172",
-                "reference": "cd9d8cf3c5804de4341c283ed787f099f5506172",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/539c6691e0623af6dc6f9c20384c120f963465a0",
+                "reference": "539c6691e0623af6dc6f9c20384c120f963465a0",
                 "shasum": ""
             },
             "require": {
@@ -1835,31 +2063,43 @@
                 }
             ],
             "description": "Provides functionality to recursively process PHP variables",
-            "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
+            "homepage": "https://github.com/sebastianbergmann/recursion-context",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
-                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.4"
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.6"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/recursion-context",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2020-10-26T13:17:30+00:00"
+            "time": "2025-08-10T06:57:39+00:00"
         },
         {
             "name": "sebastian/resource-operations",
-            "version": "3.0.3",
+            "version": "3.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/resource-operations.git",
-                "reference": "0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8"
+                "reference": "05d5692a7993ecccd56a03e40cd7e5b09b1d404e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8",
-                "reference": "0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/05d5692a7993ecccd56a03e40cd7e5b09b1d404e",
+                "reference": "05d5692a7993ecccd56a03e40cd7e5b09b1d404e",
                 "shasum": ""
             },
             "require": {
@@ -1871,7 +2111,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-main": "3.0-dev"
                 }
             },
             "autoload": {
@@ -1892,8 +2132,7 @@
             "description": "Provides a list of PHP built-in functions that operate on resources",
             "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
             "support": {
-                "issues": "https://github.com/sebastianbergmann/resource-operations/issues",
-                "source": "https://github.com/sebastianbergmann/resource-operations/tree/3.0.3"
+                "source": "https://github.com/sebastianbergmann/resource-operations/tree/3.0.4"
             },
             "funding": [
                 {
@@ -1901,20 +2140,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T06:45:17+00:00"
+            "time": "2024-03-14T16:00:52+00:00"
         },
         {
             "name": "sebastian/type",
-            "version": "3.2.0",
+            "version": "3.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/type.git",
-                "reference": "fb3fe09c5f0bae6bc27ef3ce933a1e0ed9464b6e"
+                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/fb3fe09c5f0bae6bc27ef3ce933a1e0ed9464b6e",
-                "reference": "fb3fe09c5f0bae6bc27ef3ce933a1e0ed9464b6e",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
+                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
                 "shasum": ""
             },
             "require": {
@@ -1949,7 +2188,7 @@
             "homepage": "https://github.com/sebastianbergmann/type",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/type/issues",
-                "source": "https://github.com/sebastianbergmann/type/tree/3.2.0"
+                "source": "https://github.com/sebastianbergmann/type/tree/3.2.1"
             },
             "funding": [
                 {
@@ -1957,7 +2196,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-09-12T14:47:03+00:00"
+            "time": "2023-02-03T06:13:03+00:00"
         },
         {
             "name": "sebastian/version",
@@ -2075,16 +2314,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.7.1",
+            "version": "3.13.5",
             "source": {
                 "type": "git",
-                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "1359e176e9307e906dc3d890bcc9603ff6d90619"
+                "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
+                "reference": "0ca86845ce43291e8f5692c7356fccf3bcf02bf4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/1359e176e9307e906dc3d890bcc9603ff6d90619",
-                "reference": "1359e176e9307e906dc3d890bcc9603ff6d90619",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/0ca86845ce43291e8f5692c7356fccf3bcf02bf4",
+                "reference": "0ca86845ce43291e8f5692c7356fccf3bcf02bf4",
                 "shasum": ""
             },
             "require": {
@@ -2094,18 +2333,13 @@
                 "php": ">=5.4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.3.4"
             },
             "bin": [
-                "bin/phpcs",
-                "bin/phpcbf"
+                "bin/phpcbf",
+                "bin/phpcs"
             ],
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.x-dev"
-                }
-            },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "BSD-3-Clause"
@@ -2113,34 +2347,62 @@
             "authors": [
                 {
                     "name": "Greg Sherwood",
-                    "role": "lead"
+                    "role": "Former lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "role": "Current lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer/graphs/contributors"
                 }
             ],
             "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
-            "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
+            "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer",
             "keywords": [
                 "phpcs",
-                "standards"
+                "standards",
+                "static analysis"
             ],
             "support": {
-                "issues": "https://github.com/squizlabs/PHP_CodeSniffer/issues",
-                "source": "https://github.com/squizlabs/PHP_CodeSniffer",
-                "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
+                "issues": "https://github.com/PHPCSStandards/PHP_CodeSniffer/issues",
+                "security": "https://github.com/PHPCSStandards/PHP_CodeSniffer/security/policy",
+                "source": "https://github.com/PHPCSStandards/PHP_CodeSniffer",
+                "wiki": "https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki"
             },
-            "time": "2022-06-18T07:21:10+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2025-11-04T16:30:35+00:00"
         },
         {
             "name": "theseer/tokenizer",
-            "version": "1.2.1",
+            "version": "1.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/theseer/tokenizer.git",
-                "reference": "34a41e998c2183e22995f158c581e7b5e755ab9e"
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/34a41e998c2183e22995f158c581e7b5e755ab9e",
-                "reference": "34a41e998c2183e22995f158c581e7b5e755ab9e",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/b7489ce515e168639d17feec34b8847c326b0b3c",
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c",
                 "shasum": ""
             },
             "require": {
@@ -2169,7 +2431,7 @@
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
             "support": {
                 "issues": "https://github.com/theseer/tokenizer/issues",
-                "source": "https://github.com/theseer/tokenizer/tree/1.2.1"
+                "source": "https://github.com/theseer/tokenizer/tree/1.3.1"
             },
             "funding": [
                 {
@@ -2177,34 +2439,42 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-07-28T10:34:58+00:00"
+            "time": "2025-11-17T20:03:58+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",
-            "version": "2.3.0",
+            "version": "3.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
-                "reference": "7da1894633f168fe244afc6de00d141f27517b62"
+                "reference": "7795ec6fa05663d716a549d0b44e47ffc8b0d4a6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/7da1894633f168fe244afc6de00d141f27517b62",
-                "reference": "7da1894633f168fe244afc6de00d141f27517b62",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/7795ec6fa05663d716a549d0b44e47ffc8b0d4a6",
+                "reference": "7795ec6fa05663d716a549d0b44e47ffc8b0d4a6",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.4",
-                "squizlabs/php_codesniffer": "^3.3.1"
+                "ext-filter": "*",
+                "ext-libxml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlreader": "*",
+                "php": ">=7.2",
+                "phpcsstandards/phpcsextra": "^1.5.0",
+                "phpcsstandards/phpcsutils": "^1.1.0",
+                "squizlabs/php_codesniffer": "^3.13.4"
             },
             "require-dev": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || ^0.6",
-                "phpcompatibility/php-compatibility": "^9.0",
-                "phpcsstandards/phpcsdevtools": "^1.0",
-                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+                "php-parallel-lint/php-console-highlighter": "^1.0.0",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
+                "phpcompatibility/php-compatibility": "^10.0.0@dev",
+                "phpcsstandards/phpcsdevtools": "^1.2.0",
+                "phpunit/phpunit": "^8.0 || ^9.0"
             },
             "suggest": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.6 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
+                "ext-iconv": "For improved results",
+                "ext-mbstring": "For improved results"
             },
             "type": "phpcodesniffer-standard",
             "notification-url": "https://packagist.org/downloads/",
@@ -2221,6 +2491,7 @@
             "keywords": [
                 "phpcs",
                 "standards",
+                "static analysis",
                 "wordpress"
             ],
             "support": {
@@ -2228,34 +2499,41 @@
                 "source": "https://github.com/WordPress/WordPress-Coding-Standards",
                 "wiki": "https://github.com/WordPress/WordPress-Coding-Standards/wiki"
             },
-            "time": "2020-05-13T23:57:56+00:00"
+            "funding": [
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "custom"
+                }
+            ],
+            "time": "2025-11-25T12:08:04+00:00"
         },
         {
             "name": "yoast/phpunit-polyfills",
-            "version": "1.0.3",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Yoast/PHPUnit-Polyfills.git",
-                "reference": "5ea3536428944955f969bc764bbe09738e151ada"
+                "reference": "134921bfca9b02d8f374c48381451da1d98402f9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/5ea3536428944955f969bc764bbe09738e151ada",
-                "reference": "5ea3536428944955f969bc764bbe09738e151ada",
+                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/134921bfca9b02d8f374c48381451da1d98402f9",
+                "reference": "134921bfca9b02d8f374c48381451da1d98402f9",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.4",
-                "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
+                "php": ">=7.1",
+                "phpunit/phpunit": "^7.5 || ^8.0 || ^9.0 || ^11.0 || ^12.0"
             },
             "require-dev": {
-                "yoast/yoastcs": "^2.2.0"
+                "php-parallel-lint/php-console-highlighter": "^1.0.0",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
+                "yoast/yoastcs": "^3.1.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.x-dev",
-                    "dev-develop": "1.x-dev"
+                    "dev-main": "4.x-dev"
                 }
             },
             "autoload": {
@@ -2287,17 +2565,18 @@
             ],
             "support": {
                 "issues": "https://github.com/Yoast/PHPUnit-Polyfills/issues",
+                "security": "https://github.com/Yoast/PHPUnit-Polyfills/security/policy",
                 "source": "https://github.com/Yoast/PHPUnit-Polyfills"
             },
-            "time": "2021-11-23T01:37:03+00:00"
+            "time": "2025-02-09T18:58:54+00:00"
         }
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": true,
     "prefer-lowest": false,
-    "platform": [],
-    "platform-dev": [],
-    "plugin-api-version": "2.1.0"
+    "platform": {},
+    "platform-dev": {},
+    "plugin-api-version": "2.9.0"
 }

--- a/friends-send-to-e-reader.php
+++ b/friends-send-to-e-reader.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * Plugin name: Send to E-Reader (Legacy Loader)
+ * Description: This file exists for backwards compatibility. The plugin has been renamed to Send to E-Reader.
+ *
+ * @package Send_To_E_Reader
+ * @deprecated Use send-to-e-reader.php instead.
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+require_once __DIR__ . '/send-to-e-reader.php';

--- a/includes/class-e-reader-download.php
+++ b/includes/class-e-reader-download.php
@@ -7,7 +7,7 @@
  * @package Friends_Send_To_E_Reader
  */
 
-namespace Friends;
+namespace Send_To_E_Reader;
 
 /**
  * This is the class for the sending posts to a generic E-Reader for the Friends Plugin.

--- a/includes/class-e-reader-download.php
+++ b/includes/class-e-reader-download.php
@@ -4,7 +4,7 @@
  *
  * This contains the class for a generic E-Reader that can receive ePub via e-mail.
  *
- * @package Friends_Send_To_E_Reader
+ * @package Send_To_E_Reader
  */
 
 namespace Send_To_E_Reader;
@@ -14,7 +14,7 @@ namespace Send_To_E_Reader;
  *
  * @since 0.3
  *
- * @package Friends_Send_To_E_Reader
+ * @package Send_To_E_Reader
  * @author Alex Kirk
  */
 class E_Reader_Download extends E_Reader {

--- a/includes/class-e-reader-generic-email.php
+++ b/includes/class-e-reader-generic-email.php
@@ -4,7 +4,7 @@
  *
  * This contains the class for a generic E-Reader that can receive ePub via e-mail.
  *
- * @package Friends_Send_To_E_Reader
+ * @package Send_To_E_Reader
  */
 
 namespace Send_To_E_Reader;
@@ -14,7 +14,7 @@ namespace Send_To_E_Reader;
  *
  * @since 0.3
  *
- * @package Friends_Send_To_E_Reader
+ * @package Send_To_E_Reader
  * @author Alex Kirk
  */
 class E_Reader_Generic_Email extends E_Reader {

--- a/includes/class-e-reader-generic-email.php
+++ b/includes/class-e-reader-generic-email.php
@@ -7,7 +7,7 @@
  * @package Friends_Send_To_E_Reader
  */
 
-namespace Friends;
+namespace Send_To_E_Reader;
 
 /**
  * This is the class for the sending posts to a generic E-Reader for the Friends Plugin.
@@ -88,10 +88,29 @@ class E_Reader_Generic_Email extends E_Reader {
 			return false;
 		}
 
-		$friends = Friends::get_instance();
-		$friends->notifications->send_mail( $this->email, $this->ebook_title, $this->ebook_title, array(), array( $file ) );
+		$this->send_email_with_attachment( $file );
 		unlink( $file );
 		return array( 'send-to-e-reader' => 'success', 'title' => $this->ebook_title, 'author' => $this->ebook_author );
+	}
+
+	/**
+	 * Send email with attachment, using Friends if available or wp_mail as fallback.
+	 *
+	 * @param string $file The file path to attach.
+	 */
+	protected function send_email_with_attachment( $file ) {
+		if ( class_exists( '\Friends\Friends' ) ) {
+			$friends = \Friends\Friends::get_instance();
+			$friends->notifications->send_mail( $this->email, $this->ebook_title, $this->ebook_title, array(), array( $file ) );
+		} else {
+			wp_mail(
+				$this->email,
+				$this->ebook_title,
+				$this->ebook_title,
+				array( 'Content-Type: text/plain; charset=UTF-8' ),
+				array( $file )
+			);
+		}
 	}
 
 }

--- a/includes/class-e-reader-kindle.php
+++ b/includes/class-e-reader-kindle.php
@@ -4,7 +4,7 @@
  *
  * This contains the class for a Kindle E-Reader
  *
- * @package Friends_Send_To_E_Reader
+ * @package Send_To_E_Reader
  */
 
 namespace Send_To_E_Reader;
@@ -14,7 +14,7 @@ namespace Send_To_E_Reader;
  *
  * @since 0.3
  *
- * @package Friends_Send_To_E_Reader
+ * @package Send_To_E_Reader
  * @author Alex Kirk
  */
 class E_Reader_Kindle extends E_Reader_Generic_Email {
@@ -33,7 +33,7 @@ class E_Reader_Kindle extends E_Reader_Generic_Email {
 		$this->update_author_name( $post );
 		$content = $this->get_content( 'mobi', $post );
 
-		$dir = rtrim( sys_get_temp_dir(), '/' ) . '/friends_send_to_e_reader';
+		$dir = rtrim( sys_get_temp_dir(), '/' ) . '/send_to_e_reader';
 		if ( ! file_exists( $dir ) ) {
 			mkdir( $dir );
 		}

--- a/includes/class-e-reader-kindle.php
+++ b/includes/class-e-reader-kindle.php
@@ -7,7 +7,7 @@
  * @package Friends_Send_To_E_Reader
  */
 
-namespace Friends;
+namespace Send_To_E_Reader;
 
 /**
  * This is the class for the sending posts to a Kindle E-Reader for the Friends Plugin.

--- a/includes/class-e-reader-pocketbook.php
+++ b/includes/class-e-reader-pocketbook.php
@@ -4,7 +4,7 @@
  *
  * This contains the class for a Pocketbook E-Reader
  *
- * @package Friends_Send_To_E_Reader
+ * @package Send_To_E_Reader
  */
 
 namespace Send_To_E_Reader;
@@ -14,7 +14,7 @@ namespace Send_To_E_Reader;
  *
  * @since 0.3
  *
- * @package Friends_Send_To_E_Reader
+ * @package Send_To_E_Reader
  * @author Alex Kirk
  */
 class E_Reader_Pocketbook extends E_Reader_Generic_Email {

--- a/includes/class-e-reader-pocketbook.php
+++ b/includes/class-e-reader-pocketbook.php
@@ -7,7 +7,7 @@
  * @package Friends_Send_To_E_Reader
  */
 
-namespace Friends;
+namespace Send_To_E_Reader;
 
 /**
  * This is the class for the sending posts to a Pocketbook E-Reader for the Friends Plugin.

--- a/includes/class-e-reader-tolino.php
+++ b/includes/class-e-reader-tolino.php
@@ -4,7 +4,7 @@
  *
  * This contains the class for a Tolino E-Reader
  *
- * @package Friends_Send_To_E_Reader
+ * @package Send_To_E_Reader
  */
 
 namespace Send_To_E_Reader;
@@ -14,7 +14,7 @@ namespace Send_To_E_Reader;
  *
  * @since 0.3
  *
- * @package Friends_Send_To_E_Reader
+ * @package Send_To_E_Reader
  * @author Alex Kirk
  */
 class E_Reader_Tolino extends E_Reader {

--- a/includes/class-e-reader-tolino.php
+++ b/includes/class-e-reader-tolino.php
@@ -7,7 +7,7 @@
  * @package Friends_Send_To_E_Reader
  */
 
-namespace Friends;
+namespace Send_To_E_Reader;
 
 /**
  * This is the class for the sending posts to a Tolino E-Reader for the Friends Plugin.

--- a/includes/class-e-reader.php
+++ b/includes/class-e-reader.php
@@ -4,7 +4,7 @@
  *
  * This contains an abstract class of an E-Reader
  *
- * @package Friends_Send_To_E_Reader
+ * @package Send_To_E_Reader
  */
 
 namespace Send_To_E_Reader;
@@ -14,7 +14,7 @@ namespace Send_To_E_Reader;
  *
  * @since 0.3
  *
- * @package Friends_Send_To_E_Reader
+ * @package Send_To_E_Reader
  * @author Alex Kirk
  */
 abstract class E_Reader {
@@ -178,7 +178,7 @@ abstract class E_Reader {
 		$this->ebook_title = $title;
 		$this->ebook_author = $author;
 
-		$dir = rtrim( sys_get_temp_dir(), '/' ) . '/friends_send_to_e_reader';
+		$dir = rtrim( sys_get_temp_dir(), '/' ) . '/send_to_e_reader';
 		if ( ! file_exists( $dir ) ) {
 			mkdir( $dir );
 		}

--- a/includes/class-e-reader.php
+++ b/includes/class-e-reader.php
@@ -7,7 +7,7 @@
  * @package Friends_Send_To_E_Reader
  */
 
-namespace Friends;
+namespace Send_To_E_Reader;
 
 /**
  * This is the abstract class for the sending posts to an E-Reader for the Friends Plugin.
@@ -26,6 +26,75 @@ abstract class E_Reader {
 	abstract public static function render_template( $data = array() );
 	abstract public static function instantiate_from_field_data( $id, $data );
 	abstract public function send_posts( array $posts, $title = null, $author = null );
+
+	/**
+	 * Get the template loader (Friends or fallback).
+	 *
+	 * @return object
+	 */
+	protected static function get_template_loader() {
+		if ( class_exists( '\Friends\Friends' ) ) {
+			return \Friends\Friends::template_loader();
+		}
+
+		static $loader = null;
+		if ( null === $loader ) {
+			$loader = new class {
+				private $paths = array();
+
+				public function __construct() {
+					$this->paths[] = FRIENDS_SEND_TO_E_READER_PLUGIN_DIR . 'templates/';
+				}
+
+				public function get_template_part( $slug, $name = null, $args = array(), $echo = true ) {
+					$template = $this->locate_template( $slug, $name );
+					if ( ! $template ) {
+						return '';
+					}
+
+					if ( ! $echo ) {
+						return $template;
+					}
+
+					if ( ! empty( $args ) && is_array( $args ) ) {
+						extract( $args ); // phpcs:ignore WordPress.PHP.DontExtract.extract_extract
+					}
+					include $template;
+				}
+
+				private function locate_template( $slug, $name = null ) {
+					$templates = array();
+					if ( $name ) {
+						$templates[] = "{$slug}-{$name}.php";
+					}
+					$templates[] = "{$slug}.php";
+
+					foreach ( $templates as $template ) {
+						foreach ( $this->paths as $path ) {
+							if ( file_exists( $path . $template ) ) {
+								return $path . $template;
+							}
+						}
+					}
+					return '';
+				}
+			};
+		}
+		return $loader;
+	}
+
+	/**
+	 * Get the author for a post, with Friends fallback.
+	 *
+	 * @param \WP_Post $post The post.
+	 * @return object An object with display_name property.
+	 */
+	protected static function get_post_author( \WP_Post $post ) {
+		if ( class_exists( '\Friends\User' ) ) {
+			return \Friends\User::get_post_author( $post );
+		}
+		return get_userdata( $post->post_author ) ?: (object) array( 'display_name' => __( 'Unknown', 'friends' ) );
+	}
 
 	/**
 	 * Strip Emojis from text
@@ -65,7 +134,7 @@ abstract class E_Reader {
 			$post_title = get_the_time( 'F j, Y H:i:s', $post );
 		}
 
-		Friends::template_loader()->get_template_part(
+		self::get_template_loader()->get_template_part(
 			$format . '/header',
 			null,
 			array(
@@ -77,7 +146,7 @@ abstract class E_Reader {
 
 		echo wp_kses_post( $post->post_content );
 
-		Friends::template_loader()->get_template_part(
+		self::get_template_loader()->get_template_part(
 			$format . '/footer',
 			null,
 			array(
@@ -92,7 +161,7 @@ abstract class E_Reader {
 
 	protected function update_author_name( \WP_Post $post ) {
 		if ( ! isset( $post->author_name ) ) {
-			$author = User::get_post_author( $post );
+			$author = self::get_post_author( $post );
 			$author_name = $author->display_name;
 			$override_author_name = apply_filters( 'friends_override_author_name', '', $author->display_name, $post->ID );
 			if ( $override_author_name && trim( str_replace( $override_author_name, '', $author_name ) ) === $author_name ) {
@@ -151,7 +220,7 @@ abstract class E_Reader {
 
 		$book->setSourceURL( $url );
 
-		$book->addCSSFile( 'style.css', 'css', file_get_contents( Friends::template_loader()->get_template_part( 'epub/style', null, array(), false ) ) );
+		$book->addCSSFile( 'style.css', 'css', file_get_contents( self::get_template_loader()->get_template_part( 'epub/style', null, array(), false ) ) );
 
 		foreach ( $posts as $count => $post ) {
 			$post_title = $post->post_title;

--- a/includes/class-e-reader.php
+++ b/includes/class-e-reader.php
@@ -43,7 +43,7 @@ abstract class E_Reader {
 				private $paths = array();
 
 				public function __construct() {
-					$this->paths[] = FRIENDS_SEND_TO_E_READER_PLUGIN_DIR . 'templates/';
+					$this->paths[] = SEND_TO_E_READER_PLUGIN_DIR . 'templates/';
 				}
 
 				public function get_template_part( $slug, $name = null, $args = array(), $echo = true ) {
@@ -212,7 +212,7 @@ abstract class E_Reader {
 		$filename = sanitize_title( substr( $this->ebook_author, 0, 40 ) . ' - ' . substr( $this->ebook_title, 0, 100 ) );
 		$url = home_url( '?' . implode( '-', array_map( 'intval', array_column( $posts, 'ID' ) ) ) );
 		$book = new \PHPePub\Core\EPub();
-		$book->setGenerator( 'Friends Send to E-Reader (Version ' . FRIENDS_SEND_TO_E_READER_VERSION . ')' );
+		$book->setGenerator( 'Send to E-Reader (Version ' . SEND_TO_E_READER_VERSION . ')' );
 
 		$book->setTitle( htmlspecialchars( $this->ebook_title ) );
 		$book->setIdentifier( $url, \PHPePub\Core\EPub::IDENTIFIER_URI );

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<phpunit
+	bootstrap="tests/bootstrap.php"
+	backupGlobals="false"
+	colors="true"
+	convertErrorsToExceptions="true"
+	convertNoticesToExceptions="true"
+	convertWarningsToExceptions="true"
+	>
+	<testsuites>
+		<testsuite name="Friends Send to E-Reader Test Suite">
+			<directory suffix=".php">./tests/</directory>
+			<exclude>./tests/bootstrap.php</exclude>
+		</testsuite>
+	</testsuites>
+</phpunit>

--- a/send-to-e-reader.js
+++ b/send-to-e-reader.js
@@ -11,7 +11,7 @@ jQuery( function( $ ) {
 
 		var data = {
 			ereader: $this.data( 'ereader' ),
-			_ajax_nonce: friends_send_to_ereader.nonce
+			_ajax_nonce: send_to_ereader.nonce
 		};
 
 		var show_dialog = false;
@@ -111,7 +111,7 @@ jQuery( function( $ ) {
 
 		wp.ajax.send( 'unmark-e-reader-send', {
 			data: {
-				_ajax_nonce: friends_send_to_ereader.nonce,
+				_ajax_nonce: send_to_ereader.nonce,
 				id: $this.data( 'id' )
 			},
 			beforeSend: function() {
@@ -119,7 +119,7 @@ jQuery( function( $ ) {
 			},
 			success: function( e ) {
 				search_indicator.removeClass( 'form-icon loading' ).addClass( 'dashicons dashicons-saved' );
-				$this.closest( 'li' ).prevAll().filter( '.divider.ereader' ).attr( 'data-content', friends_send_to_ereader.ereader );
+				$this.closest( 'li' ).prevAll().filter( '.divider.ereader' ).attr( 'data-content', send_to_ereader.ereader );
 			},
 			error: function( e ) {
 				search_indicator.removeClass( 'form-icon loading' ).addClass( 'dashicons dashicons-warning' ).prop( 'title', e.responseText.replace( /<\/?[^>]+(>|$)/g, '' ) );

--- a/send-to-e-reader.php
+++ b/send-to-e-reader.php
@@ -1,16 +1,16 @@
 <?php
 /**
- * Plugin name: Friends Send to E-Reader
+ * Plugin name: Send to E-Reader
  * Plugin author: Alex Kirk
- * Plugin URI: https://github.com/akirk/friends-send-to-e-reader
+ * Plugin URI: https://github.com/akirk/send-to-e-reader
  * Version: 0.8.4
  *
  * Description: Send posts to your e-reader. Works standalone or integrates with the Friends plugin.
  *
  * License: GPL2
- * Text Domain: friends
+ * Text Domain: send-to-e-reader
  *
- * @package Friends_Send_To_E_Reader
+ * @package Send_To_E_Reader
  */
 
 /**
@@ -18,21 +18,21 @@
  */
 
 defined( 'ABSPATH' ) || exit;
-define( 'FRIENDS_SEND_TO_E_READER_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
-define( 'FRIENDS_SEND_TO_E_READER_VERSION', '0.8.4' );
+define( 'SEND_TO_E_READER_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
+define( 'SEND_TO_E_READER_VERSION', '0.8.4' );
 
 require 'libs/autoload.php';
 require_once __DIR__ . '/includes/class-send-to-e-reader.php';
 require_once __DIR__ . '/includes/class-e-reader.php';
 
-add_filter( 'friends_send_to_e_reader', '__return_true' );
+add_filter( 'send_to_e_reader', '__return_true' );
 
 /**
  * Initialize the plugin with e-reader classes.
  *
- * @param Friends\Send_To_E_Reader $send_to_e_reader The Send_To_E_Reader instance.
+ * @param Send_To_E_Reader\Send_To_E_Reader $send_to_e_reader The Send_To_E_Reader instance.
  */
-function friends_send_to_e_reader_register_ereaders( $send_to_e_reader ) {
+function send_to_e_reader_register_ereaders( $send_to_e_reader ) {
 	require_once __DIR__ . '/includes/class-e-reader-generic-email.php';
 	$send_to_e_reader->register_ereader( 'Send_To_E_Reader\E_Reader_Generic_Email' );
 
@@ -57,7 +57,7 @@ add_action(
 	'friends_loaded',
 	function ( $friends ) {
 		$send_to_e_reader = new Send_To_E_Reader\Send_To_E_Reader( $friends );
-		friends_send_to_e_reader_register_ereaders( $send_to_e_reader );
+		send_to_e_reader_register_ereaders( $send_to_e_reader );
 	}
 );
 
@@ -70,7 +70,7 @@ add_action(
 			return;
 		}
 		$send_to_e_reader = new Send_To_E_Reader\Send_To_E_Reader( null );
-		friends_send_to_e_reader_register_ereaders( $send_to_e_reader );
+		send_to_e_reader_register_ereaders( $send_to_e_reader );
 	},
 	20
 );

--- a/templates/admin/automatic-sending.php
+++ b/templates/admin/automatic-sending.php
@@ -2,7 +2,7 @@
 /**
  * E-Reader Automatic Sending Settings (inserted in user pages)
  *
- * @package Friends_Send_To_E_Reader
+ * @package Send_To_E_Reader
  */
 
 return; // Not ready.

--- a/templates/admin/configure-ereaders.php
+++ b/templates/admin/configure-ereaders.php
@@ -83,15 +83,16 @@ $save_changes = __( 'Save Changes', 'friends' );
 				),
 			)
 		);
-		echo '<br/>';
-
-		echo esc_html(
-			sprintf(
-				// translators: %s is an e-mail address.
-				__( 'Make sure that you whitelist the e-mail address which the friend plugin sends its e-mails from: %s', 'friends' ),
-				$args['friends']->notifications->get_friends_plugin_from_email_address()
-			)
-		);
+		if ( $args['friends'] && isset( $args['friends']->notifications ) ) {
+			echo '<br/>';
+			echo esc_html(
+				sprintf(
+					// translators: %s is an e-mail address.
+					__( 'Make sure that you whitelist the e-mail address which the friend plugin sends its e-mails from: %s', 'friends' ),
+					$args['friends']->notifications->get_friends_plugin_from_email_address()
+				)
+			);
+		}
 
 		?>
 	</p>

--- a/templates/admin/configure-ereaders.php
+++ b/templates/admin/configure-ereaders.php
@@ -2,7 +2,7 @@
 /**
  * Configure E-Readers
  *
- * @package Friends_Send_To_E_Reader
+ * @package Send_To_E_Reader
  */
 
 $save_changes = __( 'Save Changes', 'friends' );

--- a/templates/admin/edit-notifications-ereader.php
+++ b/templates/admin/edit-notifications-ereader.php
@@ -17,7 +17,7 @@
 					sprintf(
 						// translators: %s is an URL.
 						__( 'No E-Reader available that supports sending. Go to the <a href=%s>Send to E-Reader settings</a> to add one.', 'friends' ),
-						'"' . self_admin_url( 'admin.php?page=friends-send-to-e-reader' ) . '"'
+						'"' . self_admin_url( 'admin.php?page=send-to-e-reader' ) . '"'
 					),
 					array( 'a' => array( 'href' => array() ) )
 				);

--- a/templates/admin/ereader-settings.php
+++ b/templates/admin/ereader-settings.php
@@ -61,12 +61,14 @@
 						<li><span class="description"><?php echo esc_html( $description ); ?></span> <span class="download-preview"><tt class="friends-sample-url"></tt><tt>?epub</tt><tt class="download_password_preview"><?php echo esc_html( $args['download_password'] ); ?></tt><tt>=<?php echo esc_html( $key ); ?></tt></span></li>
 						<?php endforeach; ?>
 					</ul>
+					<?php if ( ! empty( $args['all-friends'] ) && is_object( $args['all-friends'] ) ) : ?>
 					<p><select id="all-friends-preview">
 						<option value=""><?php esc_html_e( 'Preview URL for a friend', 'friends' ); ?></option>
 						<?php foreach ( $args['all-friends']->get_results() as $friend ) : ?>
 						<option value="<?php echo esc_attr( $friend->get_local_friends_page_url() ); ?>"><?php echo esc_html( $friend->display_name ); ?></option>
 						<?php endforeach; ?>
 					</select>
+					<?php endif; ?>
 				</fieldset>
 			</td>
 		</tr>

--- a/templates/admin/ereader-settings.php
+++ b/templates/admin/ereader-settings.php
@@ -2,7 +2,7 @@
 /**
  * E-Reader Settings
  *
- * @package Friends_Send_To_E_Reader
+ * @package Send_To_E_Reader
  */
 
 ?>

--- a/templates/admin/settings-footer.php
+++ b/templates/admin/settings-footer.php
@@ -1,0 +1,9 @@
+<?php
+/**
+ * Settings Footer Template (Standalone)
+ *
+ * @package Friends_Send_To_E_Reader
+ */
+
+?>
+</div>

--- a/templates/admin/settings-footer.php
+++ b/templates/admin/settings-footer.php
@@ -2,7 +2,7 @@
 /**
  * Settings Footer Template (Standalone)
  *
- * @package Friends_Send_To_E_Reader
+ * @package Send_To_E_Reader
  */
 
 ?>

--- a/templates/admin/settings-header.php
+++ b/templates/admin/settings-header.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Settings Header Template (Standalone)
+ *
+ * @package Friends_Send_To_E_Reader
+ */
+
+?>
+<div class="wrap">
+	<h1><?php echo esc_html( $args['title'] ); ?></h1>
+
+	<?php if ( ! empty( $args['menu'] ) ) : ?>
+	<h2 class="nav-tab-wrapper">
+		<?php foreach ( $args['menu'] as $label => $page ) : ?>
+			<a href="<?php echo esc_url( admin_url( 'admin.php?page=' . $page ) ); ?>" class="nav-tab<?php echo $args['active'] === $page ? ' nav-tab-active' : ''; ?>"><?php echo esc_html( $label ); ?></a>
+		<?php endforeach; ?>
+	</h2>
+	<?php endif; ?>

--- a/templates/admin/settings-header.php
+++ b/templates/admin/settings-header.php
@@ -2,7 +2,7 @@
 /**
  * Settings Header Template (Standalone)
  *
- * @package Friends_Send_To_E_Reader
+ * @package Send_To_E_Reader
  */
 
 ?>

--- a/templates/epub/header.php
+++ b/templates/epub/header.php
@@ -2,7 +2,7 @@
 /**
  * EPub header
  *
- * @package Friends_Send_To_E_Reader
+ * @package Send_To_E_Reader
  */
 
 echo '<', '?xml version="1.0" encoding="utf-8"?', '>', PHP_EOL;

--- a/templates/frontend/ereader/author-header.php
+++ b/templates/frontend/ereader/author-header.php
@@ -2,7 +2,7 @@
 /**
  * This template contains the message part for the author header on /friends/.
  *
- * @package Friends_Send_To_E_Reader
+ * @package Send_To_E_Reader
  */
 
 if ( count( $args['unsent_posts'] ) ) {

--- a/templates/plain-list.php
+++ b/templates/plain-list.php
@@ -2,7 +2,7 @@
 /**
  * This template contains the output of a simple list of posts.
  *
- * @package Friends_Send_To_E_Reader
+ * @package Send_To_E_Reader
  */
 
 ?>

--- a/tests/Test_E_Reader.php
+++ b/tests/Test_E_Reader.php
@@ -2,7 +2,7 @@
 /**
  * Tests for the E_Reader classes.
  *
- * @package Friends_Send_To_E_Reader
+ * @package Send_To_E_Reader
  */
 
 use PHPUnit\Framework\TestCase;

--- a/tests/Test_E_Reader.php
+++ b/tests/Test_E_Reader.php
@@ -1,0 +1,166 @@
+<?php
+/**
+ * Tests for the E_Reader classes.
+ *
+ * @package Friends_Send_To_E_Reader
+ */
+
+use PHPUnit\Framework\TestCase;
+use Send_To_E_Reader\E_Reader_Download;
+use Send_To_E_Reader\E_Reader_Kindle;
+use Send_To_E_Reader\E_Reader_Pocketbook;
+use Send_To_E_Reader\E_Reader_Generic_Email;
+
+/**
+ * Test class for E_Reader implementations.
+ */
+class Test_E_Reader extends TestCase {
+
+	/**
+	 * Test E_Reader_Download instantiation.
+	 */
+	public function test_e_reader_download_instantiation() {
+		$ereader = new E_Reader_Download( 'Test Download' );
+		$this->assertInstanceOf( E_Reader_Download::class, $ereader );
+		$this->assertEquals( 'Test Download', $ereader->get_name() );
+	}
+
+	/**
+	 * Test E_Reader_Download generates an ID.
+	 */
+	public function test_e_reader_download_generates_id() {
+		$ereader = new E_Reader_Download( 'Test Download' );
+		$id = $ereader->get_id();
+		$this->assertIsString( $id );
+		$this->assertNotEmpty( $id );
+	}
+
+	/**
+	 * Test E_Reader_Generic_Email instantiation.
+	 */
+	public function test_e_reader_generic_email_instantiation() {
+		$ereader = new E_Reader_Generic_Email( 'My E-Reader', 'test@example.com' );
+		$this->assertInstanceOf( E_Reader_Generic_Email::class, $ereader );
+		$this->assertEquals( 'My E-Reader', $ereader->get_name() );
+	}
+
+	/**
+	 * Test E_Reader_Generic_Email generates ID based on email.
+	 */
+	public function test_e_reader_generic_email_generates_id() {
+		$ereader = new E_Reader_Generic_Email( 'My E-Reader', 'test@example.com' );
+		$id = $ereader->get_id();
+		$this->assertIsString( $id );
+		$this->assertNotEmpty( $id );
+	}
+
+	/**
+	 * Test E_Reader_Generic_Email returns null ID when email is empty.
+	 */
+	public function test_e_reader_generic_email_null_id_without_email() {
+		$ereader = new E_Reader_Generic_Email( 'My E-Reader', '' );
+		$id = $ereader->get_id();
+		$this->assertNull( $id );
+	}
+
+	/**
+	 * Test E_Reader_Kindle instantiation.
+	 */
+	public function test_e_reader_kindle_instantiation() {
+		$ereader = new E_Reader_Kindle( 'My Kindle', 'user@free.kindle.com' );
+		$this->assertInstanceOf( E_Reader_Kindle::class, $ereader );
+		$this->assertEquals( 'My Kindle', $ereader->get_name() );
+	}
+
+	/**
+	 * Test E_Reader_Kindle is subclass of E_Reader_Generic_Email.
+	 */
+	public function test_e_reader_kindle_extends_generic_email() {
+		$ereader = new E_Reader_Kindle( 'My Kindle', 'user@free.kindle.com' );
+		$this->assertInstanceOf( E_Reader_Generic_Email::class, $ereader );
+	}
+
+	/**
+	 * Test E_Reader_Pocketbook instantiation.
+	 */
+	public function test_e_reader_pocketbook_instantiation() {
+		$ereader = new E_Reader_Pocketbook( 'My Pocketbook', 'user@pbsync.com' );
+		$this->assertInstanceOf( E_Reader_Pocketbook::class, $ereader );
+		$this->assertEquals( 'My Pocketbook', $ereader->get_name() );
+	}
+
+	/**
+	 * Test E_Reader_Pocketbook is subclass of E_Reader_Generic_Email.
+	 */
+	public function test_e_reader_pocketbook_extends_generic_email() {
+		$ereader = new E_Reader_Pocketbook( 'My Pocketbook', 'user@pbsync.com' );
+		$this->assertInstanceOf( E_Reader_Generic_Email::class, $ereader );
+	}
+
+	/**
+	 * Test E_Reader_Download::instantiate_from_field_data.
+	 */
+	public function test_e_reader_download_instantiate_from_field_data() {
+		$data = array( 'name' => 'Downloaded ePub' );
+		$ereader = E_Reader_Download::instantiate_from_field_data( 'test-id', $data );
+
+		$this->assertInstanceOf( E_Reader_Download::class, $ereader );
+		$this->assertEquals( 'Downloaded ePub', $ereader->get_name() );
+	}
+
+	/**
+	 * Test E_Reader_Generic_Email::instantiate_from_field_data.
+	 */
+	public function test_e_reader_generic_email_instantiate_from_field_data() {
+		$data = array(
+			'name'  => 'Email Reader',
+			'email' => 'reader@example.com',
+		);
+		$ereader = E_Reader_Generic_Email::instantiate_from_field_data( 'test-id', $data );
+
+		$this->assertInstanceOf( E_Reader_Generic_Email::class, $ereader );
+		$this->assertEquals( 'Email Reader', $ereader->get_name() );
+	}
+
+	/**
+	 * Test E_Reader_Kindle::get_defaults has kindle placeholder.
+	 */
+	public function test_e_reader_kindle_defaults_has_kindle_placeholder() {
+		$defaults = E_Reader_Kindle::get_defaults();
+		$this->assertArrayHasKey( 'email_placeholder', $defaults );
+		$this->assertStringContainsString( 'kindle', $defaults['email_placeholder'] );
+	}
+
+	/**
+	 * Test E_Reader_Pocketbook::get_defaults has pocketbook placeholder.
+	 */
+	public function test_e_reader_pocketbook_defaults_has_pocketbook_placeholder() {
+		$defaults = E_Reader_Pocketbook::get_defaults();
+		$this->assertArrayHasKey( 'email_placeholder', $defaults );
+		$this->assertStringContainsString( 'pbsync', $defaults['email_placeholder'] );
+	}
+
+	/**
+	 * Test E_Reader active property can be set.
+	 */
+	public function test_e_reader_active_property() {
+		$ereader = new E_Reader_Download( 'Test' );
+		$this->assertNull( $ereader->active );
+
+		$ereader->active = true;
+		$this->assertTrue( $ereader->active );
+
+		$ereader->active = false;
+		$this->assertFalse( $ereader->active );
+	}
+
+	/**
+	 * Test E_Reader NAME constant.
+	 */
+	public function test_e_reader_name_constants() {
+		$this->assertEquals( 'Download ePub', E_Reader_Download::NAME );
+		$this->assertEquals( 'ePub via E-Mail', E_Reader_Generic_Email::NAME );
+		$this->assertEquals( 'Kindle', E_Reader_Kindle::NAME );
+		$this->assertEquals( 'Pocketbook', E_Reader_Pocketbook::NAME );
+	}
+}

--- a/tests/Test_Send_To_E_Reader.php
+++ b/tests/Test_Send_To_E_Reader.php
@@ -2,7 +2,7 @@
 /**
  * Tests for the Send_To_E_Reader class.
  *
- * @package Friends_Send_To_E_Reader
+ * @package Send_To_E_Reader
  */
 
 use PHPUnit\Framework\TestCase;

--- a/tests/Test_Send_To_E_Reader.php
+++ b/tests/Test_Send_To_E_Reader.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * Tests for the Send_To_E_Reader class.
+ *
+ * @package Friends_Send_To_E_Reader
+ */
+
+use PHPUnit\Framework\TestCase;
+use Send_To_E_Reader\Send_To_E_Reader;
+use Send_To_E_Reader\E_Reader_Download;
+use Send_To_E_Reader\E_Reader_Kindle;
+use Send_To_E_Reader\E_Reader_Pocketbook;
+use Send_To_E_Reader\E_Reader_Generic_Email;
+
+/**
+ * Test class for Send_To_E_Reader.
+ */
+class Test_Send_To_E_Reader extends TestCase {
+
+	/**
+	 * Test that Send_To_E_Reader can be instantiated without Friends.
+	 */
+	public function test_can_instantiate_without_friends() {
+		$send_to_e_reader = new Send_To_E_Reader( null );
+		$this->assertInstanceOf( Send_To_E_Reader::class, $send_to_e_reader );
+	}
+
+	/**
+	 * Test that Send_To_E_Reader can be instantiated with Friends.
+	 */
+	public function test_can_instantiate_with_friends() {
+		$friends = \Friends\Friends::get_instance();
+		$send_to_e_reader = new Send_To_E_Reader( $friends );
+		$this->assertInstanceOf( Send_To_E_Reader::class, $send_to_e_reader );
+	}
+
+	/**
+	 * Test friends_is_available returns true when Friends class exists.
+	 */
+	public function test_friends_is_available_returns_true() {
+		$send_to_e_reader = new Send_To_E_Reader( null );
+		// Friends\Friends class is mocked in bootstrap, so it should be available.
+		$this->assertTrue( $send_to_e_reader->friends_is_available() );
+	}
+
+	/**
+	 * Test get_template_loader returns an object.
+	 */
+	public function test_get_template_loader_returns_object() {
+		$send_to_e_reader = new Send_To_E_Reader( null );
+		$loader = $send_to_e_reader->get_template_loader();
+		$this->assertIsObject( $loader );
+	}
+
+	/**
+	 * Test get_post_author_name returns author name for a post.
+	 */
+	public function test_get_post_author_name_returns_string() {
+		$send_to_e_reader = new Send_To_E_Reader( null );
+
+		$post = new \WP_Post();
+		$post->ID = 1;
+		$post->post_author = 1;
+		$post->post_title = 'Test Post';
+
+		$author_name = $send_to_e_reader->get_post_author_name( $post );
+		$this->assertIsString( $author_name );
+		$this->assertNotEmpty( $author_name );
+	}
+
+	/**
+	 * Test that e-reader can be registered.
+	 */
+	public function test_can_register_ereader() {
+		$send_to_e_reader = new Send_To_E_Reader( null );
+		$send_to_e_reader->register_ereader( E_Reader_Download::class );
+
+		// No exception means success - the class stores it internally.
+		$this->assertTrue( true );
+	}
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,370 @@
+<?php
+/**
+ * PHPUnit bootstrap file for Friends Send to E-Reader tests.
+ *
+ * @package Friends_Send_To_E_Reader
+ */
+
+namespace Friends {
+	class Friends {
+		private static $instance = null;
+		public $notifications;
+		public $frontend;
+
+		public function __construct() {
+			$this->notifications = new class {
+				public function send_mail( $to, $subject, $message, $headers = array(), $attachments = array() ) {
+					return true;
+				}
+				public function get_friends_plugin_from_email_address() {
+					return 'friends@example.com';
+				}
+			};
+			$this->frontend = new class {
+				public $author = null;
+			};
+		}
+
+		public static function get_instance() {
+			if ( null === self::$instance ) {
+				self::$instance = new self();
+			}
+			return self::$instance;
+		}
+
+		public static function template_loader() {
+			static $loader = null;
+			if ( null === $loader ) {
+				$loader = new class {
+					public function get_template_part( $slug, $name = null, $args = array(), $echo = true ) {
+						return '';
+					}
+				};
+			}
+			return $loader;
+		}
+
+		public static function on_frontend() {
+			return false;
+		}
+	}
+
+	class User {
+		public $ID;
+		public $display_name = 'Test User';
+
+		public function __construct( $id = null ) {
+			$this->ID = $id;
+		}
+
+		public static function get_post_author( $post ) {
+			$user = new self( $post->post_author ?? 1 );
+			$user->display_name = 'Test Author';
+			return $user;
+		}
+
+		public function get_local_friends_page_url( $post_id = null ) {
+			return '/friends/';
+		}
+	}
+
+	class User_Query {
+		public function __construct( $args = array() ) {}
+
+		public static function all_associated_users() {
+			return new self();
+		}
+
+		public function get_results() {
+			return array();
+		}
+	}
+}
+
+namespace {
+	// Define plugin constants.
+	if ( ! defined( 'FRIENDS_SEND_TO_E_READER_PLUGIN_DIR' ) ) {
+		define( 'FRIENDS_SEND_TO_E_READER_PLUGIN_DIR', dirname( __DIR__ ) . '/' );
+	}
+	if ( ! defined( 'FRIENDS_SEND_TO_E_READER_VERSION' ) ) {
+		define( 'FRIENDS_SEND_TO_E_READER_VERSION', '0.8.4' );
+	}
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', '/tmp/' );
+	}
+
+	// Load Composer autoloader.
+	require_once dirname( __DIR__ ) . '/vendor/autoload.php';
+
+	// Mock WordPress functions.
+	function __( $text, $domain = 'default' ) {
+		return $text;
+	}
+
+	function _x( $text, $context, $domain = 'default' ) {
+		return $text;
+	}
+
+	function _e( $text, $domain = 'default' ) {
+		echo $text;
+	}
+
+	function esc_html__( $text, $domain = 'default' ) {
+		return htmlspecialchars( $text, ENT_QUOTES, 'UTF-8' );
+	}
+
+	function esc_html_e( $text, $domain = 'default' ) {
+		echo esc_html__( $text, $domain );
+	}
+
+	function esc_attr__( $text, $domain = 'default' ) {
+		return htmlspecialchars( $text, ENT_QUOTES, 'UTF-8' );
+	}
+
+	function esc_attr_e( $text, $domain = 'default' ) {
+		echo esc_attr__( $text, $domain );
+	}
+
+	function esc_html( $text ) {
+		return htmlspecialchars( $text, ENT_QUOTES, 'UTF-8' );
+	}
+
+	function esc_attr( $text ) {
+		return htmlspecialchars( $text, ENT_QUOTES, 'UTF-8' );
+	}
+
+	function esc_url( $url ) {
+		return htmlspecialchars( $url, ENT_QUOTES, 'UTF-8' );
+	}
+
+	function wp_kses( $string, $allowed_html, $allowed_protocols = array() ) {
+		return $string;
+	}
+
+	function wp_kses_post( $data ) {
+		return $data;
+	}
+
+	function add_action( $tag, $function_to_add, $priority = 10, $accepted_args = 1 ) {
+		return true;
+	}
+
+	function add_filter( $tag, $function_to_add, $priority = 10, $accepted_args = 1 ) {
+		return true;
+	}
+
+	function apply_filters( $tag, $value, ...$args ) {
+		return $value;
+	}
+
+	function did_action( $hook_name ) {
+		return 0;
+	}
+
+	function get_option( $option, $default = false ) {
+		return $default;
+	}
+
+	function update_option( $option, $value, $autoload = null ) {
+		return true;
+	}
+
+	function get_user_option( $option, $user_id = 0 ) {
+		return false;
+	}
+
+	function update_user_option( $user_id, $option, $value, $global = false ) {
+		return true;
+	}
+
+	function delete_user_option( $user_id, $option, $global = false ) {
+		return true;
+	}
+
+	function get_post_meta( $post_id, $key = '', $single = false ) {
+		return $single ? '' : array();
+	}
+
+	function update_post_meta( $post_id, $meta_key, $meta_value, $prev_value = '' ) {
+		return true;
+	}
+
+	function delete_post_meta( $post_id, $meta_key, $meta_value = '' ) {
+		return true;
+	}
+
+	function wp_salt( $scheme = 'auth' ) {
+		return 'test-salt-' . $scheme;
+	}
+
+	function sanitize_title( $title, $fallback_title = '', $context = 'save' ) {
+		return preg_replace( '/[^a-z0-9-]/', '-', strtolower( $title ) );
+	}
+
+	function sanitize_text_field( $str ) {
+		return trim( strip_tags( $str ) );
+	}
+
+	function wp_unslash( $value ) {
+		return is_string( $value ) ? stripslashes( $value ) : $value;
+	}
+
+	function is_user_logged_in() {
+		return false;
+	}
+
+	function current_user_can( $capability, ...$args ) {
+		return false;
+	}
+
+	function get_the_author_meta( $field = '', $user_id = false ) {
+		if ( 'display_name' === $field ) {
+			return 'Test Author';
+		}
+		return '';
+	}
+
+	function get_userdata( $user_id ) {
+		return (object) array(
+			'ID'           => $user_id,
+			'display_name' => 'Test User',
+		);
+	}
+
+	function home_url( $path = '', $scheme = null ) {
+		return 'https://example.com' . $path;
+	}
+
+	function admin_url( $path = '', $scheme = 'admin' ) {
+		return 'https://example.com/wp-admin/' . $path;
+	}
+
+	function plugins_url( $path = '', $plugin = '' ) {
+		return 'https://example.com/wp-content/plugins/' . basename( dirname( $plugin ) ) . '/' . $path;
+	}
+
+	function get_the_time( $format = '', $post = null ) {
+		return date( $format ?: 'U' );
+	}
+
+	function get_the_title( $post = 0 ) {
+		if ( is_object( $post ) ) {
+			return $post->post_title ?? '';
+		}
+		return '';
+	}
+
+	function get_the_excerpt( $post = null ) {
+		if ( is_object( $post ) ) {
+			return $post->post_excerpt ?? '';
+		}
+		return '';
+	}
+
+	function get_the_permalink( $post = 0 ) {
+		$id = is_object( $post ) ? $post->ID : $post;
+		return 'https://example.com/?p=' . $id;
+	}
+
+	function get_permalink( $post = 0 ) {
+		return get_the_permalink( $post );
+	}
+
+	function get_post_format( $post = null ) {
+		return false;
+	}
+
+	function date_i18n( $format, $timestamp = false, $gmt = false ) {
+		return date( $format, $timestamp ?: time() );
+	}
+
+	function wp_create_nonce( $action = -1 ) {
+		return 'test-nonce-' . $action;
+	}
+
+	function wp_verify_nonce( $nonce, $action = -1 ) {
+		return 1;
+	}
+
+	function check_ajax_referer( $action = -1, $query_arg = false, $die = true ) {
+		return true;
+	}
+
+	function wp_send_json_success( $data = null, $status_code = null ) {
+		echo json_encode( array( 'success' => true, 'data' => $data ) );
+	}
+
+	function wp_send_json_error( $data = null, $status_code = null ) {
+		echo json_encode( array( 'success' => false, 'data' => $data ) );
+	}
+
+	function is_wp_error( $thing ) {
+		return $thing instanceof \WP_Error;
+	}
+
+	class WP_Error {
+		public $errors = array();
+		public $error_data = array();
+
+		public function __construct( $code = '', $message = '', $data = '' ) {
+			if ( $code ) {
+				$this->errors[ $code ][] = $message;
+				if ( $data ) {
+					$this->error_data[ $code ] = $data;
+				}
+			}
+		}
+
+		public function get_error_message( $code = '' ) {
+			if ( empty( $code ) ) {
+				$code = array_key_first( $this->errors );
+			}
+			return $this->errors[ $code ][0] ?? '';
+		}
+	}
+
+	class WP_Query {
+		public $query_vars = array();
+		private $posts = array();
+
+		public function __construct( $query = '' ) {
+			$this->query_vars = is_array( $query ) ? $query : array();
+		}
+
+		public function get_posts() {
+			return $this->posts;
+		}
+	}
+
+	class WP_Post {
+		public $ID = 0;
+		public $post_author = 1;
+		public $post_title = '';
+		public $post_content = '';
+		public $post_excerpt = '';
+		public $post_status = 'publish';
+
+		public function __construct( $post = null ) {
+			if ( is_object( $post ) ) {
+				foreach ( get_object_vars( $post ) as $key => $value ) {
+					$this->$key = $value;
+				}
+			}
+		}
+	}
+
+	function get_post( $post = null ) {
+		if ( $post instanceof WP_Post ) {
+			return $post;
+		}
+		return new WP_Post( $post );
+	}
+
+	// Load the plugin files.
+	require_once FRIENDS_SEND_TO_E_READER_PLUGIN_DIR . 'includes/class-e-reader.php';
+	require_once FRIENDS_SEND_TO_E_READER_PLUGIN_DIR . 'includes/class-send-to-e-reader.php';
+	require_once FRIENDS_SEND_TO_E_READER_PLUGIN_DIR . 'includes/class-e-reader-download.php';
+	require_once FRIENDS_SEND_TO_E_READER_PLUGIN_DIR . 'includes/class-e-reader-generic-email.php';
+	require_once FRIENDS_SEND_TO_E_READER_PLUGIN_DIR . 'includes/class-e-reader-kindle.php';
+	require_once FRIENDS_SEND_TO_E_READER_PLUGIN_DIR . 'includes/class-e-reader-pocketbook.php';
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -2,7 +2,7 @@
 /**
  * PHPUnit bootstrap file for Friends Send to E-Reader tests.
  *
- * @package Friends_Send_To_E_Reader
+ * @package Send_To_E_Reader
  */
 
 namespace Friends {


### PR DESCRIPTION
## Summary

- Decouples the Send to E-Reader plugin from the Friends plugin dependency, allowing it to work as a standalone WordPress plugin
- Renames plugin files from `friends-send-to-e-reader.*` to `send-to-e-reader.*`
- Adds standalone settings pages and admin UI when Friends plugin is not active
- Adds test infrastructure with PHPUnit configuration and initial test suite

## Test plan

- [ ] Install plugin without Friends plugin active and verify settings pages work
- [ ] Configure an e-reader and test sending content
- [ ] Install with Friends plugin active and verify integration still works
- [ ] Run PHPUnit tests