### PR TITLE
Add AI Assistant EPUB export

### DIFF
--- a/includes/class-ai-assistant-integration.php
+++ b/includes/class-ai-assistant-integration.php
@@ -1,0 +1,531 @@
+<?php
+/**
+ * AI Assistant integration.
+ *
+ * @package Send_To_E_Reader
+ */
+
+namespace Send_To_E_Reader;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Adds Send to E-Reader export formats to AI Assistant.
+ */
+class AI_Assistant_Integration {
+	/**
+	 * Register WordPress hooks.
+	 */
+	public static function register_hooks() {
+		add_filter( 'ai_assistant_conversation_export_formats', array( __CLASS__, 'register_export_formats' ), 100, 2 );
+	}
+
+	/**
+	 * Add the EPUB conversation export format.
+	 *
+	 * @param array      $formats      Existing export formats.
+	 * @param array|null $conversation Conversation export data, if available.
+	 * @return array
+	 */
+	public static function register_export_formats( $formats, $conversation = null ) {
+		$formats = (array) $formats;
+
+		$epub_format = isset( $formats['epub'] ) ? $formats['epub'] : array(
+				'label'       => __( 'EPUB', 'send-to-e-reader' ),
+				'description' => __( 'E-reader friendly conversation export.', 'send-to-e-reader' ),
+				'extension'   => 'epub',
+				'mime'        => Epub_Builder::MIME,
+				'callback'    => array( __CLASS__, 'export_conversation_epub' ),
+		);
+
+		unset( $formats['epub'] );
+		$formats['epub'] = $epub_format;
+
+		return $formats;
+	}
+
+	/**
+	 * Export an AI Assistant conversation as an ePub.
+	 *
+	 * @param array $conversation Conversation export data.
+	 * @param array $format       Export format definition.
+	 * @return array
+	 */
+	public static function export_conversation_epub( array $conversation, array $format ) {
+		$messages = isset( $conversation['messages'] ) && is_array( $conversation['messages'] ) ? $conversation['messages'] : array();
+		$messages = apply_filters( 'ai_assistant_conversation_export_shrink_tool_calls', $messages, $conversation, $format );
+		$title    = self::single_line_text( ! empty( $conversation['title'] ) ? $conversation['title'] : __( 'Conversation', 'send-to-e-reader' ) );
+		$author   = self::get_author_name( $conversation );
+		$source   = self::get_conversation_url( $conversation );
+		$chapters = self::conversation_to_chapters( $conversation, $messages, $author, $source );
+
+		return array(
+			'filename' => self::build_export_filename( $conversation, $format ),
+			'mime'     => Epub_Builder::MIME,
+			'content'  => Epub_Builder::build_content(
+				$title,
+				$author,
+				$chapters,
+				array(
+					'identifier'  => $source,
+					'source_url'  => $source,
+					'description' => isset( $conversation['summary'] ) ? $conversation['summary'] : '',
+					'date'        => isset( $conversation['created'] ) ? $conversation['created'] : '',
+				)
+			),
+		);
+	}
+
+	/**
+	 * Convert conversation data to ePub chapters.
+	 *
+	 * @param array  $conversation Conversation export data.
+	 * @param array  $messages     Conversation messages.
+	 * @param string $author       Export author.
+	 * @param string $source       Conversation source URL.
+	 * @return array
+	 */
+	private static function conversation_to_chapters( array $conversation, array $messages, $author, $source ) {
+		$include_tool_calls   = ! empty( $conversation['include_tool_calls'] );
+		$conversation_title   = self::single_line_text( ! empty( $conversation['title'] ) ? $conversation['title'] : __( 'Conversation', 'send-to-e-reader' ) );
+		$conversation_byline  = self::build_byline( $author, self::format_conversation_date( isset( $conversation['created'] ) ? $conversation['created'] : '' ) );
+		$conversation_summary = ! empty( $conversation['summary'] ) ? self::plain_text_to_xhtml( $conversation['summary'] ) : '';
+		$meta_sentence        = self::conversation_meta_sentence( $conversation );
+		$body                 = '';
+
+		if ( '' !== $conversation_summary ) {
+			$body .= '<h2>' . self::escape_xml( __( 'Summary', 'send-to-e-reader' ) ) . '</h2>' . PHP_EOL;
+			$body .= $conversation_summary . PHP_EOL;
+		}
+
+		if ( '' !== $meta_sentence ) {
+			$body .= '<p>' . self::escape_xml( $meta_sentence ) . '</p>' . PHP_EOL;
+		}
+
+		if ( '' === trim( $body ) ) {
+			$body = '<p>' . self::escape_xml( __( 'No conversation details available.', 'send-to-e-reader' ) ) . '</p>';
+		}
+
+		$body .= '<h2>' . self::escape_xml( __( 'Messages', 'send-to-e-reader' ) ) . '</h2>' . PHP_EOL;
+		$rendered_messages = 0;
+
+		foreach ( $messages as $index => $message ) {
+			if ( ! is_array( $message ) ) {
+				continue;
+			}
+
+			$role    = self::get_message_role( $message );
+			$content = self::message_to_plain_text( $message, $include_tool_calls );
+			if ( '' === $content && ! $include_tool_calls ) {
+				continue;
+			}
+
+			$message_title = self::get_message_heading( $role, $author );
+
+			$body .= '<div class="message message-' . self::html_class( $role ) . '">' . PHP_EOL;
+			$body .= '<h3>' . self::escape_xml( $message_title ) . '</h3>' . PHP_EOL;
+			$body .= self::plain_text_to_xhtml( $content ? $content : __( 'No text content', 'send-to-e-reader' ) );
+			$body .= '</div>' . PHP_EOL;
+			++$rendered_messages;
+		}
+
+		if ( 0 === $rendered_messages ) {
+			$body .= '<p>' . self::escape_xml( __( 'No messages available.', 'send-to-e-reader' ) ) . '</p>' . PHP_EOL;
+		}
+
+		return array(
+			array(
+				'title'      => $conversation_title,
+				'filename'   => 'conversation.html',
+				'content'    => Epub_Builder::wrap_xhtml( $conversation_title, $conversation_byline, $body, $source ),
+				'auto_split' => true,
+			),
+		);
+	}
+
+	/**
+	 * Build a short conversation metadata sentence.
+	 *
+	 * @param array $conversation Conversation export data.
+	 * @return string
+	 */
+	private static function conversation_meta_sentence( array $conversation ) {
+		$sentence = '';
+
+		if ( isset( $conversation['message_count'] ) ) {
+			$message_count = intval( $conversation['message_count'] );
+			$sentence      = sprintf(
+				/* translators: 1: Number of conversation messages, 2: message/messages. */
+				__( 'This conversation contains %d %s', 'send-to-e-reader' ),
+				$message_count,
+				1 === $message_count ? __( 'message', 'send-to-e-reader' ) : __( 'messages', 'send-to-e-reader' )
+			);
+		}
+
+		$provider = ! empty( $conversation['provider'] ) ? self::single_line_text( $conversation['provider'] ) : '';
+		$model    = ! empty( $conversation['model'] ) ? self::single_line_text( $conversation['model'] ) : '';
+
+		if ( '' !== $provider && '' !== $model ) {
+			$created = sprintf(
+				/* translators: 1: AI provider, 2: AI model. */
+				__( 'was created with %1$s using %2$s', 'send-to-e-reader' ),
+				$provider,
+				$model
+			);
+		} elseif ( '' !== $provider ) {
+			$created = sprintf(
+				/* translators: %s is an AI provider. */
+				__( 'was created with %s', 'send-to-e-reader' ),
+				$provider
+			);
+		} elseif ( '' !== $model ) {
+			$created = sprintf(
+				/* translators: %s is an AI model. */
+				__( 'was created using %s', 'send-to-e-reader' ),
+				$model
+			);
+		}
+
+		if ( ! empty( $created ) ) {
+			if ( '' === $sentence ) {
+				$sentence = __( 'This conversation', 'send-to-e-reader' ) . ' ' . $created;
+			} else {
+				$sentence .= ' ' . __( 'and', 'send-to-e-reader' ) . ' ' . $created;
+			}
+		}
+
+		return $sentence ? $sentence . '.' : '';
+	}
+
+	/**
+	 * Convert a message to readable plain text.
+	 *
+	 * @param array $message            Message data.
+	 * @param bool  $include_tool_calls Whether tool calls should be included.
+	 * @return string
+	 */
+	private static function message_to_plain_text( array $message, $include_tool_calls = false ) {
+		$parts   = array();
+		$content = self::message_content_to_plain_text( isset( $message['content'] ) ? $message['content'] : '', $include_tool_calls );
+
+		if ( '' !== $content ) {
+			$parts[] = $content;
+		}
+
+		if ( $include_tool_calls && ! empty( $message['tool_calls'] ) && is_array( $message['tool_calls'] ) ) {
+			foreach ( $message['tool_calls'] as $tool_call ) {
+				if ( ! is_array( $tool_call ) ) {
+					continue;
+				}
+
+				$tool_name = isset( $tool_call['function']['name'] ) ? $tool_call['function']['name'] : 'unknown';
+				$text      = '[Tool: ' . $tool_name . ']';
+				if ( isset( $tool_call['function']['arguments'] ) && '' !== $tool_call['function']['arguments'] ) {
+					$text .= "\n" . self::format_jsonish_text( $tool_call['function']['arguments'] );
+				}
+				$parts[] = $text;
+			}
+		}
+
+		return trim( implode( "\n\n", $parts ) );
+	}
+
+	/**
+	 * Convert message content to readable plain text.
+	 *
+	 * @param mixed $content            Message content.
+	 * @param bool  $include_tool_calls Whether tool calls should be included.
+	 * @return string
+	 */
+	private static function message_content_to_plain_text( $content, $include_tool_calls = false ) {
+		if ( is_string( $content ) ) {
+			return trim( self::strip_file_context_for_display( $content ) );
+		}
+
+		if ( ! is_array( $content ) ) {
+			return '';
+		}
+
+		$parts = array();
+		foreach ( $content as $block ) {
+			if ( is_string( $block ) ) {
+				$parts[] = self::strip_file_context_for_display( $block );
+				continue;
+			}
+
+			if ( ! is_array( $block ) ) {
+				continue;
+			}
+
+			$type = isset( $block['type'] ) ? $block['type'] : '';
+			if ( 'text' === $type && isset( $block['text'] ) ) {
+				$parts[] = self::strip_file_context_for_display( (string) $block['text'] );
+			} elseif ( 'tool_use' === $type ) {
+				if ( ! $include_tool_calls ) {
+					continue;
+				}
+				$tool = isset( $block['name'] ) ? $block['name'] : 'unknown';
+				$text = '[Tool: ' . $tool . ']';
+				if ( isset( $block['input'] ) ) {
+					$text .= "\n" . ( is_string( $block['input'] ) ? self::format_jsonish_text( $block['input'] ) : self::json_encode( $block['input'] ) );
+				}
+				$parts[] = $text;
+			} elseif ( 'tool_result' === $type ) {
+				if ( ! $include_tool_calls ) {
+					continue;
+				}
+				$text = '[Tool Result]';
+				if ( isset( $block['content'] ) ) {
+					$result_text = self::message_content_to_plain_text( $block['content'], $include_tool_calls );
+					if ( '' !== $result_text ) {
+						$text .= "\n" . $result_text;
+					}
+				}
+				$parts[] = $text;
+			} elseif ( $include_tool_calls ) {
+				$parts[] = self::json_encode( $block );
+			}
+		}
+
+		$parts = array_filter(
+			$parts,
+			function ( $part ) {
+				return '' !== trim( (string) $part );
+			}
+		);
+
+		return trim( implode( "\n\n", $parts ) );
+	}
+
+	/**
+	 * Convert plain text to XHTML paragraphs.
+	 *
+	 * @param string $text Plain text.
+	 * @return string
+	 */
+	private static function plain_text_to_xhtml( $text ) {
+		$text       = trim( (string) $text );
+		$paragraphs = preg_split( "/\n{2,}/", $text );
+		$html       = '';
+
+		foreach ( $paragraphs as $paragraph ) {
+			$paragraph = trim( $paragraph );
+			if ( '' === $paragraph ) {
+				continue;
+			}
+
+			$html .= '<p>' . nl2br( self::escape_xml( $paragraph ), true ) . '</p>' . PHP_EOL;
+		}
+
+		return $html;
+	}
+
+	/**
+	 * Strip AI Assistant hidden file context and keep a readable attachment summary.
+	 *
+	 * @param string $content Message content.
+	 * @return string
+	 */
+	private static function strip_file_context_for_display( $content ) {
+		if ( ! is_string( $content ) ) {
+			return $content;
+		}
+
+		if ( ! preg_match( '/\n*<ai_assistant_file_context>\n(.*?)\n<\/ai_assistant_file_context>/s', $content, $matches ) ) {
+			return $content;
+		}
+
+		$visible = trim( str_replace( $matches[0], '', $content ) );
+		$payload = json_decode( $matches[1], true );
+		$files   = is_array( $payload ) && isset( $payload['files'] ) && is_array( $payload['files'] ) ? $payload['files'] : array();
+
+		if ( empty( $files ) ) {
+			return $visible;
+		}
+
+		$summary = "\n\n[Attached files]\n";
+		foreach ( $files as $file ) {
+			if ( ! is_array( $file ) ) {
+				continue;
+			}
+
+			$name     = isset( $file['original_name'] ) ? $file['original_name'] : ( isset( $file['filename'] ) ? $file['filename'] : __( 'Attachment', 'send-to-e-reader' ) );
+			$path     = isset( $file['wp_content_path'] ) ? $file['wp_content_path'] : '';
+			$summary .= '- ' . $name . ( $path ? ' (' . $path . ')' : '' ) . "\n";
+		}
+
+		return ( $visible ? $visible : __( 'Attached files', 'send-to-e-reader' ) ) . rtrim( $summary );
+	}
+
+	/**
+	 * Get a display role for an exported message.
+	 *
+	 * @param array $message Message data.
+	 * @return string
+	 */
+	private static function get_message_role( array $message ) {
+		$role = self::single_line_text( isset( $message['role'] ) ? $message['role'] : __( 'message', 'send-to-e-reader' ) );
+		if ( 'tool' === $role && ! empty( $message['name'] ) ) {
+			$role .= ': ' . self::single_line_text( $message['name'] );
+		}
+
+		return $role;
+	}
+
+	/**
+	 * Get the visible heading for a message.
+	 *
+	 * @param string $role   Message role.
+	 * @param string $author Conversation author display name.
+	 * @return string
+	 */
+	private static function get_message_heading( $role, $author ) {
+		if ( 'user' === strtolower( (string) $role ) && '' !== self::single_line_text( $author ) ) {
+			return $author;
+		}
+
+		return ucfirst( $role );
+	}
+
+	/**
+	 * Build a short chapter byline.
+	 *
+	 * @param string $author Author name.
+	 * @param string $date   Date string.
+	 * @return string
+	 */
+	private static function build_byline( $author, $date ) {
+		$parts = array_filter( array( self::single_line_text( $author ), self::single_line_text( $date ) ) );
+
+		return implode( ' | ', $parts );
+	}
+
+	/**
+	 * Format a conversation date for the ePub chapter header.
+	 *
+	 * @param string $date Date string.
+	 * @return string
+	 */
+	private static function format_conversation_date( $date ) {
+		if ( empty( $date ) ) {
+			return '';
+		}
+
+		$timestamp = strtotime( (string) $date );
+		if ( ! $timestamp ) {
+			return self::single_line_text( $date );
+		}
+
+		return date_i18n( _x( 'l, F j, Y', 'date format', 'send-to-e-reader' ), $timestamp );
+	}
+
+	/**
+	 * Build a conversation source URL.
+	 *
+	 * @param array $conversation Conversation export data.
+	 * @return string
+	 */
+	private static function get_conversation_url( array $conversation ) {
+		if ( ! empty( $conversation['id'] ) ) {
+			return admin_url( 'post.php?post=' . intval( $conversation['id'] ) . '&action=edit' );
+		}
+
+		return home_url( '/' );
+	}
+
+	/**
+	 * Get the export author name.
+	 *
+	 * @param array $conversation Conversation export data.
+	 * @return string
+	 */
+	private static function get_author_name( array $conversation ) {
+		if ( ! empty( $conversation['author_id'] ) ) {
+			$user = get_userdata( intval( $conversation['author_id'] ) );
+			if ( $user && ! empty( $user->display_name ) ) {
+				return $user->display_name;
+			}
+		}
+
+		return get_bloginfo( 'name' );
+	}
+
+	/**
+	 * Build the download filename.
+	 *
+	 * @param array $conversation Conversation export data.
+	 * @param array $format       Format definition.
+	 * @return string
+	 */
+	private static function build_export_filename( array $conversation, array $format ) {
+		$title = sanitize_file_name( ! empty( $conversation['title'] ) ? $conversation['title'] : 'conversation' );
+		if ( '' === $title ) {
+			$title = 'conversation';
+		}
+
+		$extension = ! empty( $format['extension'] ) ? $format['extension'] : 'epub';
+
+		return sprintf( 'ai-conversation-%d-%s.%s', ! empty( $conversation['id'] ) ? intval( $conversation['id'] ) : 0, $title, $extension );
+	}
+
+	/**
+	 * Pretty-print JSON strings when possible.
+	 *
+	 * @param mixed $text Input text.
+	 * @return string
+	 */
+	private static function format_jsonish_text( $text ) {
+		$decoded = json_decode( (string) $text, true );
+		if ( JSON_ERROR_NONE === json_last_error() ) {
+			return self::json_encode( $decoded );
+		}
+
+		return (string) $text;
+	}
+
+	/**
+	 * Encode JSON consistently.
+	 *
+	 * @param mixed $value Value to encode.
+	 * @return string
+	 */
+	private static function json_encode( $value ) {
+		if ( function_exists( 'wp_json_encode' ) ) {
+			return wp_json_encode( $value, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );
+		}
+
+		return json_encode( $value, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );
+	}
+
+	/**
+	 * Normalize text to a single line.
+	 *
+	 * @param string $text Text.
+	 * @return string
+	 */
+	private static function single_line_text( $text ) {
+		return trim( preg_replace( '/\s+/', ' ', (string) $text ) );
+	}
+
+	/**
+	 * Convert text to a safe HTML class fragment.
+	 *
+	 * @param string $text Text.
+	 * @return string
+	 */
+	private static function html_class( $text ) {
+		return preg_replace( '/[^a-z0-9_-]/', '-', strtolower( (string) $text ) );
+	}
+
+	/**
+	 * Escape text for XHTML.
+	 *
+	 * @param string $text Text.
+	 * @return string
+	 */
+	private static function escape_xml( $text ) {
+		$text = preg_replace( '/[\x00-\x08\x0B\x0C\x0E-\x1F]/', '', (string) $text );
+
+		return htmlspecialchars( $text, ENT_QUOTES | ENT_SUBSTITUTE | ENT_XML1, 'UTF-8' );
+	}
+}

--- a/includes/class-e-reader.php
+++ b/includes/class-e-reader.php
@@ -106,27 +106,7 @@ abstract class E_Reader {
 	 * @return     string  The text stripped off emojis.
 	 */
 	protected function strip_emojis( $text ) {
-		// Match Emoticons.
-		$regex_emoticons = '/[\x{1F600}-\x{1F64F}]/u';
-		$text = preg_replace( $regex_emoticons, '', $text );
-
-		// Match Miscellaneous Symbols and Pictographs.
-		$regex_symbols = '/[\x{1F300}-\x{1F5FF}]/u';
-		$text = preg_replace( $regex_symbols, '', $text );
-
-		// Match Transport And Map Symbols.
-		$regex_transport = '/[\x{1F680}-\x{1F6FF}]/u';
-		$text = preg_replace( $regex_transport, '', $text );
-
-		// Match Miscellaneous Symbols.
-		$regex_misc = '/[\x{2600}-\x{26FF}]/u';
-		$text = preg_replace( $regex_misc, '', $text );
-
-		// Match Dingbats.
-		$regex_dingbats = '/[\x{2700}-\x{27BF}]/u';
-		$text = preg_replace( $regex_dingbats, '', $text );
-
-		return $text;
+		return Epub_Builder::strip_emojis( $text );
 	}
 
 	protected function get_content( $format, \WP_Post $post ) {
@@ -177,13 +157,9 @@ abstract class E_Reader {
 
 	protected function generate_file( array $posts, $title = null, $author = null ) {
 		$authors = array();
+		$chapters = array();
 		$this->ebook_title = $title;
 		$this->ebook_author = $author;
-
-		$dir = rtrim( sys_get_temp_dir(), '/' ) . '/send_to_e_reader';
-		if ( ! file_exists( $dir ) ) {
-			wp_mkdir_p( $dir );
-		}
 
 		foreach ( $posts as $post ) {
 			if ( ! $this->ebook_title ) {
@@ -211,20 +187,9 @@ abstract class E_Reader {
 		$this->ebook_title = $this->strip_emojis( $this->ebook_title );
 		$this->ebook_author = $this->strip_emojis( $this->ebook_author );
 
-		$filename = sanitize_title( substr( $this->ebook_author, 0, 40 ) . ' - ' . substr( $this->ebook_title, 0, 100 ) );
 		$url = home_url( '?' . implode( '-', array_map( 'intval', array_column( $posts, 'ID' ) ) ) );
-		$book = new \PHPePub\Core\EPub();
-		$book->setGenerator( 'Send to E-Reader (Version ' . SEND_TO_E_READER_VERSION . ')' );
 
-		$book->setTitle( htmlspecialchars( $this->ebook_title ) );
-		$book->setIdentifier( $url, \PHPePub\Core\EPub::IDENTIFIER_URI );
-		$book->setAuthor( htmlspecialchars( $this->ebook_author ), htmlspecialchars( $this->ebook_author ) );
-
-		$book->setSourceURL( $url );
-
-		$book->addCSSFile( 'style.css', 'css', file_get_contents( self::get_template_loader()->get_template_part( 'epub/style', null, array(), false ) ) );
-
-		foreach ( $posts as $count => $post ) {
+		foreach ( $posts as $post ) {
 			$post_title = $post->post_title;
 			if ( empty( $post_title ) ) {
 				$post_title = get_the_excerpt( $post );
@@ -232,16 +197,21 @@ abstract class E_Reader {
 
 			$content = $this->get_content( 'epub', $post );
 
-			$book->addChapter( $post_title, sanitize_title( substr( $this->strip_emojis( $post->post_author ), 0, 40 ) . ' - ' . substr( $post_title, 0, 100 ) ) . '.html', $content, false, \PHPePub\Core\EPub::EXTERNAL_REF_ADD, $dir );
+			$chapters[] = array(
+				'title'    => $post_title,
+				'filename' => sanitize_title( substr( $this->strip_emojis( $post->post_author ), 0, 40 ) . ' - ' . substr( $post_title, 0, 100 ) ) . '.html',
+				'content'  => $content,
+			);
 		}
 
-		if ( count( $posts ) > 1 ) {
-			$book->buildTOC( null, 'toc', __( 'Table of Contents', 'send-to-e-reader' ), true, true );
-		}
-
-		$book->finalize();
-		$book->saveBook( $filename . '.epub', $dir );
-
-		return $dir . '/' . $filename . '.epub';
+		return Epub_Builder::build_file(
+			$this->ebook_title,
+			$this->ebook_author,
+			$chapters,
+			array(
+				'identifier' => $url,
+				'source_url' => $url,
+			)
+		);
 	}
 }

--- a/includes/class-epub-builder.php
+++ b/includes/class-epub-builder.php
@@ -1,0 +1,280 @@
+<?php
+/**
+ * Epub Builder
+ *
+ * Shared ePub generation for post downloads and integrations.
+ *
+ * @package Send_To_E_Reader
+ */
+
+namespace Send_To_E_Reader;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Builds ePub files from prepared XHTML chapters.
+ */
+class Epub_Builder {
+	const MIME = 'application/epub+zip';
+
+	/**
+	 * Build an ePub and return its binary contents.
+	 *
+	 * @param string $title    The book title.
+	 * @param string $author   The book author.
+	 * @param array  $chapters Prepared chapters.
+	 * @param array  $args     Optional generation arguments.
+	 * @return string
+	 */
+	public static function build_content( $title, $author, array $chapters, array $args = array() ) {
+		$book = self::build_book( $title, $author, $chapters, $args );
+
+		return $book->getBook();
+	}
+
+	/**
+	 * Build an ePub file and return its path.
+	 *
+	 * @param string $title    The book title.
+	 * @param string $author   The book author.
+	 * @param array  $chapters Prepared chapters.
+	 * @param array  $args     Optional generation arguments.
+	 * @return string|false
+	 */
+	public static function build_file( $title, $author, array $chapters, array $args = array() ) {
+		$dir = self::get_temp_dir();
+		if ( ! file_exists( $dir ) ) {
+			wp_mkdir_p( $dir );
+		}
+
+		$args['base_dir'] = $dir;
+		$filename         = self::build_book_filename( $title, $author );
+		$book             = self::build_book( $title, $author, $chapters, $args );
+
+		if ( false === $book->saveBook( $filename . '.epub', $dir ) ) {
+			return false;
+		}
+
+		return $dir . '/' . $filename . '.epub';
+	}
+
+	/**
+	 * Wrap content in the XHTML shell used inside an ePub chapter.
+	 *
+	 * @param string $title     Chapter title.
+	 * @param string $byline    Chapter byline.
+	 * @param string $body_html Escaped XHTML body content.
+	 * @param string $url       Optional source URL.
+	 * @return string
+	 */
+	public static function wrap_xhtml( $title, $byline, $body_html, $url = '' ) {
+		$content  = '<?xml version="1.0" encoding="utf-8"?>' . PHP_EOL;
+		$content .= '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN"' . PHP_EOL;
+		$content .= "\t" . '"http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">' . PHP_EOL;
+		$content .= '<html xmlns="http://www.w3.org/1999/xhtml">' . PHP_EOL;
+		$content .= '<head>' . PHP_EOL;
+		$content .= '<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />' . PHP_EOL;
+		$content .= '<link rel="stylesheet" type="text/css" href="style.css" />' . PHP_EOL;
+		$content .= '<title>' . self::escape_xml( $title ) . '</title>' . PHP_EOL;
+		$content .= '</head>' . PHP_EOL;
+		$content .= '<body>' . PHP_EOL;
+		$content .= "\t" . '<h1>' . self::escape_xml( $title ) . '</h1>' . PHP_EOL;
+		$content .= "\t" . '<hr />' . PHP_EOL;
+
+		if ( '' !== trim( $byline ) ) {
+			$content .= "\t" . '<h6 class="author">' . self::escape_xml( $byline ) . '</h6>' . PHP_EOL;
+		}
+
+		$content .= $body_html . PHP_EOL;
+
+		if ( '' !== trim( $url ) ) {
+			$content .= '<hr />' . PHP_EOL;
+			$content .= '<p><em><a href="' . esc_url( $url ) . '">' . self::escape_xml( $url ) . '</a></em></p>' . PHP_EOL;
+		}
+
+		$content .= '</body>' . PHP_EOL;
+		$content .= '</html>' . PHP_EOL;
+
+		return $content;
+	}
+
+	/**
+	 * Strip emoji characters from ePub metadata.
+	 *
+	 * @param string $text The text.
+	 * @return string
+	 */
+	public static function strip_emojis( $text ) {
+		$text = (string) $text;
+
+		// Match Emoticons.
+		$text = preg_replace( '/[\x{1F600}-\x{1F64F}]/u', '', $text );
+
+		// Match Miscellaneous Symbols and Pictographs.
+		$text = preg_replace( '/[\x{1F300}-\x{1F5FF}]/u', '', $text );
+
+		// Match Transport And Map Symbols.
+		$text = preg_replace( '/[\x{1F680}-\x{1F6FF}]/u', '', $text );
+
+		// Match Miscellaneous Symbols.
+		$text = preg_replace( '/[\x{2600}-\x{26FF}]/u', '', $text );
+
+		// Match Dingbats.
+		$text = preg_replace( '/[\x{2700}-\x{27BF}]/u', '', $text );
+
+		return $text;
+	}
+
+	/**
+	 * Build a PHPePub book.
+	 *
+	 * @param string $title    The book title.
+	 * @param string $author   The book author.
+	 * @param array  $chapters Prepared chapters.
+	 * @param array  $args     Optional generation arguments.
+	 * @return \PHPePub\Core\EPub
+	 */
+	private static function build_book( $title, $author, array $chapters, array $args = array() ) {
+		$title      = self::strip_emojis( $title );
+		$author     = self::strip_emojis( $author );
+		$identifier = ! empty( $args['identifier'] ) ? (string) $args['identifier'] : home_url( '/' );
+		$source_url = ! empty( $args['source_url'] ) ? (string) $args['source_url'] : $identifier;
+		$base_dir   = ! empty( $args['base_dir'] ) ? (string) $args['base_dir'] : '';
+
+		$book = new \PHPePub\Core\EPub();
+		$book->setGenerator( 'Send to E-Reader (Version ' . SEND_TO_E_READER_VERSION . ')' );
+		$book->setTitle( self::escape_xml( $title ) );
+		$book->setIdentifier( $identifier, \PHPePub\Core\EPub::IDENTIFIER_URI );
+		$book->setAuthor( self::escape_xml( $author ), self::escape_xml( $author ) );
+		$book->setSourceURL( $source_url );
+
+		if ( ! empty( $args['description'] ) ) {
+			$book->setDescription( self::sanitize_xml_text( $args['description'] ) );
+		}
+
+		if ( ! empty( $args['date'] ) ) {
+			$timestamp = is_numeric( $args['date'] ) ? (int) $args['date'] : strtotime( (string) $args['date'] );
+			if ( $timestamp ) {
+				$book->setDate( $timestamp );
+			}
+		}
+
+		$style_path = self::get_template_file( 'epub/style' );
+		if ( $style_path && file_exists( $style_path ) ) {
+			$book->addCSSFile( 'style.css', 'css', file_get_contents( $style_path ) );
+		}
+
+		$chapter_count = 0;
+		foreach ( $chapters as $count => $chapter ) {
+			if ( ! is_array( $chapter ) || empty( $chapter['content'] ) ) {
+				continue;
+			}
+
+			$chapter_title = ! empty( $chapter['title'] ) ? (string) $chapter['title'] : sprintf(
+				/* translators: %d is a chapter number. */
+				__( 'Chapter %d', 'send-to-e-reader' ),
+				$count + 1
+			);
+			$file_name     = ! empty( $chapter['filename'] ) ? (string) $chapter['filename'] : self::build_chapter_filename( $chapter_title, $count );
+			$chapter_base  = array_key_exists( 'base_dir', $chapter ) ? (string) $chapter['base_dir'] : $base_dir;
+
+			$book->addChapter(
+				$chapter_title,
+				$file_name,
+				$chapter['content'],
+				! empty( $chapter['auto_split'] ),
+				isset( $chapter['external_references'] ) ? $chapter['external_references'] : \PHPePub\Core\EPub::EXTERNAL_REF_ADD,
+				$chapter_base
+			);
+			++$chapter_count;
+		}
+
+		if ( $chapter_count > 1 ) {
+			$book->buildTOC( null, 'toc', __( 'Table of Contents', 'send-to-e-reader' ), true, true );
+		}
+
+		$book->finalize();
+
+		return $book;
+	}
+
+	/**
+	 * Build a filesystem-safe ePub filename.
+	 *
+	 * @param string $title  The book title.
+	 * @param string $author The book author.
+	 * @return string
+	 */
+	private static function build_book_filename( $title, $author ) {
+		$filename = sanitize_title( substr( (string) $author, 0, 40 ) . ' - ' . substr( (string) $title, 0, 100 ) );
+
+		return $filename ? $filename : 'ebook';
+	}
+
+	/**
+	 * Build a filesystem-safe chapter filename.
+	 *
+	 * @param string $title The chapter title.
+	 * @param int    $index Zero-based chapter index.
+	 * @return string
+	 */
+	private static function build_chapter_filename( $title, $index ) {
+		$filename = sanitize_title( substr( self::strip_emojis( $title ), 0, 100 ) );
+		if ( ! $filename ) {
+			$filename = 'chapter-' . ( $index + 1 );
+		}
+
+		return $filename . '.html';
+	}
+
+	/**
+	 * Get the temporary directory used for generated ePub files.
+	 *
+	 * @return string
+	 */
+	private static function get_temp_dir() {
+		return rtrim( sys_get_temp_dir(), '/' ) . '/send_to_e_reader';
+	}
+
+	/**
+	 * Resolve a plugin template file.
+	 *
+	 * @param string $slug Template slug.
+	 * @return string
+	 */
+	private static function get_template_file( $slug ) {
+		if ( class_exists( '\Friends\Friends' ) ) {
+			$template = \Friends\Friends::template_loader()->get_template_part( $slug, null, array(), false );
+			if ( $template && file_exists( $template ) ) {
+				return $template;
+			}
+		}
+
+		$fallback = SEND_TO_E_READER_PLUGIN_DIR . 'templates/' . $slug . '.php';
+		if ( file_exists( $fallback ) ) {
+			return $fallback;
+		}
+
+		return '';
+	}
+
+	/**
+	 * Escape text for XHTML.
+	 *
+	 * @param string $text The text.
+	 * @return string
+	 */
+	private static function escape_xml( $text ) {
+		return htmlspecialchars( self::sanitize_xml_text( $text ), ENT_QUOTES | ENT_SUBSTITUTE | ENT_XML1, 'UTF-8' );
+	}
+
+	/**
+	 * Remove characters that are invalid in XML.
+	 *
+	 * @param string $text The text.
+	 * @return string
+	 */
+	private static function sanitize_xml_text( $text ) {
+		return preg_replace( '/[\x00-\x08\x0B\x0C\x0E-\x1F]/', '', (string) $text );
+	}
+}

--- a/send-to-e-reader.php
+++ b/send-to-e-reader.php
@@ -26,10 +26,13 @@ define( 'SEND_TO_E_READER_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'SEND_TO_E_READER_VERSION', '1.1.0' );
 
 require 'libs/autoload.php';
+require_once __DIR__ . '/includes/class-epub-builder.php';
+require_once __DIR__ . '/includes/class-ai-assistant-integration.php';
 require_once __DIR__ . '/includes/class-send-to-e-reader.php';
 require_once __DIR__ . '/includes/class-e-reader.php';
 
 add_filter( 'send_to_e_reader', '__return_true' );
+Send_To_E_Reader\AI_Assistant_Integration::register_hooks();
 
 /**
  * Initialize the plugin with e-reader classes.

--- a/tests/Test_AI_Assistant_Integration.php
+++ b/tests/Test_AI_Assistant_Integration.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * Tests for the AI Assistant integration.
+ *
+ * @package Send_To_E_Reader
+ */
+
+use PHPUnit\Framework\TestCase;
+use Send_To_E_Reader\AI_Assistant_Integration;
+
+/**
+ * Test class for AI Assistant integration.
+ */
+class Test_AI_Assistant_Integration extends TestCase {
+
+	/**
+	 * Test that the EPUB export format is registered.
+	 */
+	public function test_registers_epub_export_format() {
+		$formats = AI_Assistant_Integration::register_export_formats( array() );
+
+		$this->assertArrayHasKey( 'epub', $formats );
+		$this->assertSame( 'EPUB', $formats['epub']['label'] );
+		$this->assertSame( 'epub', $formats['epub']['extension'] );
+		$this->assertSame( 'application/epub+zip', $formats['epub']['mime'] );
+		$this->assertIsCallable( $formats['epub']['callback'] );
+	}
+
+	/**
+	 * Test that a conversation can be exported as an EPUB binary.
+	 */
+	public function test_exports_conversation_epub() {
+		$format = AI_Assistant_Integration::register_export_formats( array() )['epub'];
+
+		$result = AI_Assistant_Integration::export_conversation_epub(
+			array(
+				'id'                 => 123,
+				'title'              => 'Homepage copy edits',
+				'summary'            => 'The user asked for a shorter hero headline.',
+				'message_count'      => 2,
+				'provider'           => 'openai',
+				'model'              => 'gpt-4o',
+				'created'            => '2026-05-13 10:00:00',
+				'modified'           => '2026-05-13 10:04:00',
+				'author_id'          => 1,
+				'include_tool_calls' => false,
+				'messages'           => array(
+					array(
+						'role'    => 'user',
+						'content' => 'Make the homepage hero headline shorter.',
+					),
+					array(
+						'role'    => 'assistant',
+						'content' => array(
+							array(
+								'type' => 'text',
+								'text' => 'Try "Build faster with WordPress" as the headline.',
+							),
+						),
+					),
+				),
+			),
+			$format
+		);
+
+		$this->assertSame( 'application/epub+zip', $result['mime'] );
+		$this->assertSame( 'ai-conversation-123-Homepage-copy-edits.epub', $result['filename'] );
+		$this->assertStringStartsWith( 'PK', $result['content'] );
+
+		if ( ! class_exists( 'ZipArchive' ) ) {
+			$this->markTestSkipped( 'ZipArchive is required to inspect the generated ePub.' );
+		}
+
+		$path = tempnam( sys_get_temp_dir(), 'ai-assistant-epub-' );
+		file_put_contents( $path, $result['content'] );
+
+		$zip = new ZipArchive();
+		$this->assertTrue( $zip->open( $path ) );
+		$this->assertNotFalse( $zip->locateName( 'OEBPS/conversation.html' ) );
+		$this->assertFalse( $zip->locateName( 'OEBPS/message-001.html' ) );
+
+		$chapter = $zip->getFromName( 'OEBPS/conversation.html' );
+		$zip->close();
+		unlink( $path );
+
+		$this->assertStringContainsString( 'Make the homepage hero headline shorter.', $chapter );
+		$this->assertStringContainsString( 'Try &quot;Build faster with WordPress&quot; as the headline.', $chapter );
+		$this->assertStringContainsString( 'Test User | Wednesday, May 13, 2026', $chapter );
+		$this->assertStringContainsString( 'This conversation contains 2 messages and was created with openai using gpt-4o.', $chapter );
+		$this->assertStringContainsString( '<h3>Test User</h3>', $chapter );
+		$this->assertStringContainsString( '<h3>Assistant</h3>', $chapter );
+		$this->assertStringNotContainsString( '<table>', $chapter );
+		$this->assertStringNotContainsString( '<th>Messages</th>', $chapter );
+		$this->assertStringNotContainsString( '<th>Provider</th>', $chapter );
+		$this->assertStringNotContainsString( '<th>Model</th>', $chapter );
+		$this->assertStringNotContainsString( 'Conversation ID', $chapter );
+		$this->assertStringNotContainsString( 'Created', $chapter );
+		$this->assertStringNotContainsString( 'Modified', $chapter );
+		$this->assertStringNotContainsString( '<h3>User</h3>', $chapter );
+		$this->assertStringNotContainsString( 'User 1', $chapter );
+		$this->assertStringNotContainsString( 'Assistant 2', $chapter );
+	}
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -89,12 +89,38 @@ namespace {
 	if ( ! defined( 'FRIENDS_SEND_TO_E_READER_VERSION' ) ) {
 		define( 'FRIENDS_SEND_TO_E_READER_VERSION', '0.8.4' );
 	}
+	if ( ! defined( 'SEND_TO_E_READER_PLUGIN_DIR' ) ) {
+		define( 'SEND_TO_E_READER_PLUGIN_DIR', FRIENDS_SEND_TO_E_READER_PLUGIN_DIR );
+	}
+	if ( ! defined( 'SEND_TO_E_READER_VERSION' ) ) {
+		define( 'SEND_TO_E_READER_VERSION', FRIENDS_SEND_TO_E_READER_VERSION );
+	}
 	if ( ! defined( 'ABSPATH' ) ) {
 		define( 'ABSPATH', '/tmp/' );
 	}
 
 	// Load Composer autoloader.
 	require_once dirname( __DIR__ ) . '/vendor/autoload.php';
+
+	if ( ! class_exists( 'RelativePath', false ) ) {
+		require_once dirname( __DIR__ ) . '/libs/grandt/relativepath/RelativePath.php';
+	}
+
+	// The checked-in vendor tree used by these tests can omit the runtime phpzip package.
+	spl_autoload_register(
+		function ( $class ) {
+			$prefix = 'PHPZip\\Zip\\';
+			if ( 0 !== strpos( $class, $prefix ) ) {
+				return;
+			}
+
+			$relative = str_replace( '\\', '/', substr( $class, strlen( $prefix ) ) );
+			$file = dirname( __DIR__ ) . '/libs/phpzip/phpzip/src/Zip/' . $relative . '.php';
+			if ( file_exists( $file ) ) {
+				require_once $file;
+			}
+		}
+	);
 
 	// Mock WordPress functions.
 	function __( $text, $domain = 'default' ) {
@@ -203,6 +229,18 @@ namespace {
 
 	function sanitize_text_field( $str ) {
 		return trim( strip_tags( $str ) );
+	}
+
+	function sanitize_file_name( $filename ) {
+		return preg_replace( '/[^A-Za-z0-9._-]/', '-', $filename );
+	}
+
+	function get_bloginfo( $show = '', $filter = 'raw' ) {
+		return 'Test Site';
+	}
+
+	function wp_json_encode( $data, $options = 0, $depth = 512 ) {
+		return json_encode( $data, $options, $depth );
 	}
 
 	function wp_unslash( $value ) {
@@ -361,6 +399,8 @@ namespace {
 	}
 
 	// Load the plugin files.
+	require_once FRIENDS_SEND_TO_E_READER_PLUGIN_DIR . 'includes/class-epub-builder.php';
+	require_once FRIENDS_SEND_TO_E_READER_PLUGIN_DIR . 'includes/class-ai-assistant-integration.php';
 	require_once FRIENDS_SEND_TO_E_READER_PLUGIN_DIR . 'includes/class-e-reader.php';
 	require_once FRIENDS_SEND_TO_E_READER_PLUGIN_DIR . 'includes/class-send-to-e-reader.php';
 	require_once FRIENDS_SEND_TO_E_READER_PLUGIN_DIR . 'includes/class-e-reader-download.php';


### PR DESCRIPTION
## Summary
- register EPUB as the final AI Assistant conversation export format
- refactor EPUB generation into a shared builder reused by post downloads and AI exports
- render AI conversations as a continuous transcript with display-name headings and prose metadata

## Verification
- php -l includes/class-ai-assistant-integration.php
- php -l includes/class-epub-builder.php
- php -l includes/class-e-reader.php
- php -l send-to-e-reader.php
- php -l tests/bootstrap.php
- php -l tests/Test_AI_Assistant_Integration.php
- EPUB smoke check confirms one conversation chapter, display-name user heading, prose metadata, and no details table

Composer test/check-cs remain blocked by missing checked-in dev binaries/autoload mappings in vendor.