### PR TITLE
Improve standalone admin messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Stable tag: 1.1.0
 
 Send your posts to your e-reader device as an ePub file by email or download.
 
+[Try it in WordPress Playground](https://playground.wordpress.net/?blueprint-url=https%3A%2F%2Fraw.githubusercontent.com%2Fakirk%2Fsend-to-e-reader%2Fmain%2Fblueprint.json)
+
 ## Description
 
 Send posts to your e-reader as ePub files - either via e-mail or direct download.

--- a/includes/class-send-to-e-reader.php
+++ b/includes/class-send-to-e-reader.php
@@ -383,11 +383,13 @@ class Send_To_E_Reader {
 		}
 	}
 
-	public function admin_enqueue_scripts() {
+	public function admin_enqueue_scripts( $hook_suffix = '' ) {
 		$friends_available = $this->friends_is_available();
 		$page = isset( $_GET['page'] ) ? sanitize_key( wp_unslash( $_GET['page'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- read-only screen detection.
+		$plugin_pages = array( 'send-to-e-reader', 'send-to-e-reader-ereaders', 'send-to-e-reader-settings' );
+		$is_plugin_page = in_array( $page, $plugin_pages, true ) || false !== strpos( $hook_suffix, 'send-to-e-reader' );
 
-		if ( ! $friends_available && ! in_array( $page, array( 'send-to-e-reader', 'send-to-e-reader-ereaders', 'send-to-e-reader-settings' ), true ) ) {
+		if ( ! $friends_available && ! $is_plugin_page ) {
 			return;
 		}
 
@@ -395,7 +397,7 @@ class Send_To_E_Reader {
 		$file = 'send-to-e-reader.js';
 		$version = SEND_TO_E_READER_VERSION;
 		$dependencies = $friends_available ? array( 'friends-admin' ) : array( 'jquery' );
-		wp_enqueue_script( $handle, plugins_url( $file, __DIR__ ), $dependencies, apply_filters( 'friends_debug_enqueue', $version, $handle, dirname( __DIR__ ) . '/' . $file ), true );
+		wp_enqueue_script( $handle, plugins_url( $file, SEND_TO_E_READER_PLUGIN_DIR . 'send-to-e-reader.php' ), $dependencies, apply_filters( 'friends_debug_enqueue', $version, $handle, dirname( __DIR__ ) . '/' . $file ), true );
 	}
 
 	public function admin_menu() {

--- a/includes/class-send-to-e-reader.php
+++ b/includes/class-send-to-e-reader.php
@@ -399,10 +399,18 @@ class Send_To_E_Reader {
 		if ( $friends_settings_exist ) {
 			add_submenu_page(
 				'friends',
+				__( 'Send to E-Reader', 'send-to-e-reader' ),
+				__( 'Send to E-Reader', 'send-to-e-reader' ),
+				'edit_private_posts',
+				'send-to-e-reader',
+				array( $this, 'about' )
+			);
+			add_submenu_page(
+				'friends',
 				__( 'E-Readers', 'send-to-e-reader' ),
 				__( 'E-Readers', 'send-to-e-reader' ),
 				'edit_private_posts',
-				'send-to-e-reader',
+				'send-to-e-reader-ereaders',
 				array( $this, 'configure_ereaders' )
 			);
 			add_submenu_page(
@@ -416,11 +424,19 @@ class Send_To_E_Reader {
 		} else {
 			add_submenu_page(
 				'tools.php',
+				__( 'Send to E-Reader', 'send-to-e-reader' ),
+				__( 'Send to E-Reader', 'send-to-e-reader' ),
+				'edit_private_posts',
+				'send-to-e-reader',
+				array( $this, 'about' )
+			);
+			add_submenu_page(
+				'tools.php',
 				__( 'E-Readers', 'send-to-e-reader' ),
 				__( 'E-Readers', 'send-to-e-reader' ),
 				'edit_private_posts',
-				'send-to-e-reader',
-				array( $this, 'configure_ereaders_with_friends_about' )
+				'send-to-e-reader-ereaders',
+				array( $this, 'configure_ereaders' )
 			);
 			add_submenu_page(
 				'options-general.php',
@@ -660,11 +676,29 @@ class Send_To_E_Reader {
 				'active' => $active,
 				'title'  => __( 'Send to E-Reader', 'send-to-e-reader' ),
 				'menu'   => array(
-					__( 'E-Readers', 'send-to-e-reader' ) => 'send-to-e-reader',
-					__( 'Settings' )             => 'send-to-e-reader-settings', // phpcs:ignore WordPress.WP.I18n.MissingArgDomain
+					__( 'How it works', 'send-to-e-reader' ) => 'send-to-e-reader',
+					__( 'E-Readers', 'send-to-e-reader' )    => 'send-to-e-reader-ereaders',
+					__( 'Settings' )                         => 'send-to-e-reader-settings', // phpcs:ignore WordPress.WP.I18n.MissingArgDomain
 				),
 			)
 		);
+	}
+
+	/**
+	 * Display the plugin overview page.
+	 */
+	public function about() {
+		$this->settings_header( 'send-to-e-reader' );
+
+		$this->get_template_loader()->get_template_part(
+			'admin/about',
+			null,
+			array(
+				'friends_available' => $this->friends_is_available(),
+			)
+		);
+
+		$this->get_template_loader()->get_template_part( 'admin/ereader-settings-footer' );
 	}
 
 	/**
@@ -700,10 +734,8 @@ class Send_To_E_Reader {
 
 	/**
 	 * Display the configure e-readers page for the plugin.
-	 *
-	 * @param      bool $display_about_friends  The display about friends section.
 	 */
-	public function configure_ereaders( $display_about_friends = false ) {
+	public function configure_ereaders() {
 		$ereaders = $this->get_ereaders();
 
 		$friends = $this->friends_is_available() ? \Friends\Friends::get_instance() : null;
@@ -750,7 +782,7 @@ class Send_To_E_Reader {
 			$this->update_ereaders( $ereaders );
 		}
 
-		$this->settings_header( 'send-to-e-reader' );
+		$this->settings_header( 'send-to-e-reader-ereaders' );
 
 		$this->get_template_loader()->get_template_part(
 			'admin/configure-ereaders',
@@ -759,19 +791,11 @@ class Send_To_E_Reader {
 				'ereaders'              => $ereaders,
 				'nonce_value'           => $nonce_value,
 				'friends'               => $friends,
-				'display_about_friends' => $display_about_friends,
 				'ereader_classes'       => $this->ereader_classes,
 			)
 		);
 
 		$this->get_template_loader()->get_template_part( 'admin/ereader-settings-footer' );
-	}
-
-	/**
-	 * Display an about page for the plugin with the friends section.
-	 */
-	public function configure_ereaders_with_friends_about() {
-		return $this->configure_ereaders( true );
 	}
 
 	/**
@@ -1085,7 +1109,7 @@ class Send_To_E_Reader {
 						printf(
 							/* translators: %s is a link to the settings page */
 							esc_html__( 'No active E-Reader configured. Please configure one in the %s.', 'send-to-e-reader' ),
-							'<a href="' . esc_url( admin_url( 'options-general.php?page=send-to-e-reader-settings' ) ) . '">' . esc_html__( 'settings', 'send-to-e-reader' ) . '</a>'
+							'<a href="' . esc_url( admin_url( 'admin.php?page=send-to-e-reader-ereaders' ) ) . '">' . esc_html__( 'E-Readers', 'send-to-e-reader' ) . '</a>'
 						);
 					?></p>
 				</div>

--- a/includes/class-send-to-e-reader.php
+++ b/includes/class-send-to-e-reader.php
@@ -384,13 +384,18 @@ class Send_To_E_Reader {
 	}
 
 	public function admin_enqueue_scripts() {
-		if ( ! $this->friends_is_available() ) {
+		$friends_available = $this->friends_is_available();
+		$page = isset( $_GET['page'] ) ? sanitize_key( wp_unslash( $_GET['page'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- read-only screen detection.
+
+		if ( ! $friends_available && ! in_array( $page, array( 'send-to-e-reader', 'send-to-e-reader-ereaders', 'send-to-e-reader-settings' ), true ) ) {
 			return;
 		}
+
 		$handle = 'send-to-e-reader';
 		$file = 'send-to-e-reader.js';
 		$version = SEND_TO_E_READER_VERSION;
-		wp_enqueue_script( $handle, plugins_url( $file, __DIR__ ), array( 'friends-admin' ), apply_filters( 'friends_debug_enqueue', $version, $handle, dirname( __DIR__ ) . '/' . $file ), true );
+		$dependencies = $friends_available ? array( 'friends-admin' ) : array( 'jquery' );
+		wp_enqueue_script( $handle, plugins_url( $file, __DIR__ ), $dependencies, apply_filters( 'friends_debug_enqueue', $version, $handle, dirname( __DIR__ ) . '/' . $file ), true );
 	}
 
 	public function admin_menu() {

--- a/send-to-e-reader.js
+++ b/send-to-e-reader.js
@@ -117,7 +117,7 @@ jQuery( function( $ ) {
 		return false;
 	} );
 
-	$document.on( 'click', 'a#add-reader', function() {
+	$document.on( 'click', '#add-reader', function() {
 		$( 'tr.template' ).removeClass( 'hidden' ).find( 'input:visible:first' ).focus();
 		$( this ).remove();
 		return false;

--- a/send-to-e-reader.js
+++ b/send-to-e-reader.js
@@ -1,7 +1,7 @@
 jQuery( function( $ ) {
 	var $document = $( document );
 
-	wp = wp || {};
+	window.wp = window.wp || {};
 	$document.on( 'click', 'a.friends-send-post-to-e-reader,a.friends-send-new-posts-to-ereader', function() {
 		var $this = $(this);
 		var search_indicator = $this.find( 'i' );

--- a/templates/admin/about.php
+++ b/templates/admin/about.php
@@ -48,7 +48,7 @@ defined( 'ABSPATH' ) || exit;
 				sprintf(
 					// translators: %s: URL to the Friends plugin page on WordPress.org.
 					__( 'Optional: install the <a href="%s">Friends plugin</a> to follow feeds and send friend posts to your e-reader from inside WordPress.', 'send-to-e-reader' ),
-					esc_url( admin_url( 'plugin-install.php?s=Friends&tab=search&type=term' ) )
+					esc_url( admin_url( 'plugin-install.php?s=friends&tab=search&type=term' ) )
 				),
 				array(
 					'a' => array(

--- a/templates/admin/about.php
+++ b/templates/admin/about.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * Plugin overview.
+ *
+ * @package Send_To_E_Reader
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+?>
+<h2><?php esc_html_e( 'How it works', 'send-to-e-reader' ); ?></h2>
+<p>
+	<?php esc_html_e( 'Send to E-Reader turns one or more WordPress posts into an ePub file. You can download the ePub directly or send it to a configured e-reader address.', 'send-to-e-reader' ); ?>
+</p>
+
+<h2><?php esc_html_e( 'Where to find it', 'send-to-e-reader' ); ?></h2>
+<ul class="ul-disc">
+	<li>
+		<?php
+		echo wp_kses(
+			sprintf(
+				// translators: %s: URL to the WordPress Posts admin page.
+				__( 'On the <a href="%s">Posts</a> screen, use the <strong>Send to E-Reader</strong> row action for a single post.', 'send-to-e-reader' ),
+				esc_url( admin_url( 'edit.php' ) )
+			),
+			array(
+				'a'      => array(
+					'href' => array(),
+				),
+				'strong' => array(),
+			)
+		);
+		?>
+	</li>
+	<li>
+		<?php esc_html_e( 'On the Posts screen, select multiple posts and choose Send to E-Reader from the Bulk actions menu.', 'send-to-e-reader' ); ?>
+	</li>
+	<li>
+		<?php esc_html_e( 'With the Friends plugin installed, use the e-reader actions on friend and feed posts, or configure automatic sending for new articles.', 'send-to-e-reader' ); ?>
+	</li>
+</ul>
+
+<?php if ( ! $args['friends_available'] ) : ?>
+	<div class="notice notice-info inline">
+		<p>
+			<?php
+			echo wp_kses(
+				sprintf(
+					// translators: %s: URL to the Friends plugin page on WordPress.org.
+					__( 'Optional: install the <a href="%s">Friends plugin</a> to follow feeds and send friend posts to your e-reader from inside WordPress.', 'send-to-e-reader' ),
+					esc_url( admin_url( 'plugin-install.php?s=Friends&tab=search&type=term' ) )
+				),
+				array(
+					'a' => array(
+						'href' => array(),
+					),
+				)
+			);
+			?>
+		</p>
+	</div>
+<?php endif; ?>
+
+<h2><?php esc_html_e( 'Delivery', 'send-to-e-reader' ); ?></h2>
+<p>
+	<?php
+	echo wp_kses(
+		sprintf(
+			// translators: %s: URL to the E-Readers settings tab.
+			__( 'The default <strong>Download ePub</strong> reader creates a downloadable file. Add e-mail based readers on the <a href="%s">E-Readers</a> tab for wireless delivery.', 'send-to-e-reader' ),
+			esc_url( admin_url( 'admin.php?page=send-to-e-reader-ereaders' ) )
+		),
+		array(
+			'a'      => array(
+				'href' => array(),
+			),
+			'strong' => array(),
+		)
+	);
+	?>
+</p>
+
+<p class="description">
+<?php
+echo wp_kses(
+	// translators: %s: URL to the PHPePub library.
+	sprintf( __( 'Powered by <a href="%s">PHPePub</a>.', 'send-to-e-reader' ), 'https://github.com/Grandt/PHPePub' ),
+	array(
+		'a' => array(
+			'href' => array(),
+		),
+	)
+);
+?>
+</p>

--- a/templates/admin/about.php
+++ b/templates/admin/about.php
@@ -36,30 +36,22 @@ defined( 'ABSPATH' ) || exit;
 		<?php esc_html_e( 'On the Posts screen, select multiple posts and choose Send to E-Reader from the Bulk actions menu.', 'send-to-e-reader' ); ?>
 	</li>
 	<li>
-		<?php esc_html_e( 'With the Friends plugin installed, use the e-reader actions on friend and feed posts, or configure automatic sending for new articles.', 'send-to-e-reader' ); ?>
+		<?php
+		echo wp_kses(
+			sprintf(
+				// translators: %s: URL to install or manage the Friends plugin.
+				__( 'With the <a href="%s">Friends plugin</a> installed, use the e-reader actions on friend and feed posts, or configure automatic sending for new articles.', 'send-to-e-reader' ),
+				esc_url( $args['friends_available'] ? admin_url( 'admin.php?page=friends' ) : admin_url( 'plugin-install.php?s=friends&tab=search&type=term' ) )
+			),
+			array(
+				'a' => array(
+					'href' => array(),
+				),
+			)
+		);
+		?>
 	</li>
 </ul>
-
-<?php if ( ! $args['friends_available'] ) : ?>
-	<div class="notice notice-info inline">
-		<p>
-			<?php
-			echo wp_kses(
-				sprintf(
-					// translators: %s: URL to the Friends plugin page on WordPress.org.
-					__( 'Optional: install the <a href="%s">Friends plugin</a> to follow feeds and send friend posts to your e-reader from inside WordPress.', 'send-to-e-reader' ),
-					esc_url( admin_url( 'plugin-install.php?s=friends&tab=search&type=term' ) )
-				),
-				array(
-					'a' => array(
-						'href' => array(),
-					),
-				)
-			);
-			?>
-		</p>
-	</div>
-<?php endif; ?>
 
 <h2><?php esc_html_e( 'Delivery', 'send-to-e-reader' ); ?></h2>
 <p>

--- a/templates/admin/configure-ereaders.php
+++ b/templates/admin/configure-ereaders.php
@@ -10,27 +10,6 @@ defined( 'ABSPATH' ) || exit;
 $save_changes = __( 'Save Changes', 'send-to-e-reader' );
 
 ?>
-<?php if ( $args['display_about_friends'] ) : ?>
-	<h2><?php esc_html_e( 'How to send posts', 'send-to-e-reader' ); ?></h2>
-	<p>
-		<?php
-		echo wp_kses(
-			sprintf(
-				// translators: %s: URL to the WordPress Posts admin page.
-				__( 'Use <strong>Send to E-Reader</strong> on the <a href="%s">Posts</a> screen for a single post, or select several posts and run <strong>Bulk actions > Send to E-Reader</strong>. The default <strong>Download ePub</strong> reader creates an ePub download.', 'send-to-e-reader' ),
-				esc_url( admin_url( 'edit.php' ) )
-			),
-			array(
-				'a'      => array(
-					'href' => array(),
-				),
-				'strong' => array(),
-			)
-		);
-		?>
-	</p>
-<?php endif; ?>
-
 <form method="post">
 	<?php wp_nonce_field( $args['nonce_value'] ); ?>
 	<h2><?php esc_html_e( 'Delivery options', 'send-to-e-reader' ); ?></h2>
@@ -119,34 +98,4 @@ $save_changes = __( 'Save Changes', 'send-to-e-reader' );
 		<input type="submit" id="submit" class="button button-primary" value="<?php echo esc_html( $save_changes ); ?>">
 	</p>
 </form>
-
-<p class="description">
-<?php
-if ( $args['display_about_friends'] ) {
-	echo wp_kses(
-		// translators: %1$s: URL to the Friends Plugin page on WordPress.org, %2$s: URL to the PHPePub library.
-		sprintf( __( 'Optional: integrate with the Friends plugin for friend and feed posts (<a href=%1$s>learn more</a>). Powered by <a href=%2$s>PHPePub</a>.', 'send-to-e-reader' ), 'https://wordpress.org/plugins/friends" target="_blank" rel="noopener noreferrer', 'https://github.com/Grandt/PHPePub" target="_blank" rel="noopener noreferrer' ),
-		array(
-			'a' => array(
-				'href'   => array(),
-				'rel'    => array(),
-				'target' => array(),
-			),
-		)
-	);
-} else {
-	echo wp_kses(
-		// translators: %s: URL to the PHPePub library.
-		sprintf( __( 'Powered by <a href=%s>PHPePub</a>.', 'send-to-e-reader' ), 'https://github.com/Grandt/PHPePub" target="_blank" rel="noopener noreferrer' ),
-		array(
-			'a' => array(
-				'href'   => array(),
-				'rel'    => array(),
-				'target' => array(),
-			),
-		)
-	);
-}
-?>
-</p>
 <?php

--- a/templates/admin/configure-ereaders.php
+++ b/templates/admin/configure-ereaders.php
@@ -62,7 +62,7 @@ $save_changes = __( 'Save Changes', 'send-to-e-reader' );
 		</tbody>
 	</table>
 	<?php if ( ! empty( $args['ereaders'] ) ) : ?>
-		<a href="" id="add-reader"><?php esc_html_e( 'Add another E-Reader', 'send-to-e-reader' ); ?></a>
+		<button type="button" id="add-reader" class="button button-secondary"><?php esc_html_e( 'Add another E-Reader', 'send-to-e-reader' ); ?></button>
 	<?php endif; ?>
 	<p class="description">
 		<?php

--- a/templates/admin/configure-ereaders.php
+++ b/templates/admin/configure-ereaders.php
@@ -10,6 +10,34 @@ defined( 'ABSPATH' ) || exit;
 $save_changes = __( 'Save Changes', 'send-to-e-reader' );
 
 ?>
+<?php if ( $args['display_about_friends'] ) : ?>
+	<div class="notice notice-info inline">
+		<p>
+			<strong><?php esc_html_e( 'Using Send to E-Reader without Friends', 'send-to-e-reader' ); ?></strong>
+		</p>
+		<p>
+			<?php
+			echo wp_kses(
+				sprintf(
+					// translators: %s: URL to the WordPress Posts admin page.
+					__( 'Open the <a href="%s">Posts</a> screen, select one or more posts, and choose <strong>Send to E-Reader</strong> from the Bulk actions menu. You can also use the <strong>Send to E-Reader</strong> row action on an individual post.', 'send-to-e-reader' ),
+					esc_url( admin_url( 'edit.php' ) )
+				),
+				array(
+					'a'      => array(
+						'href' => array(),
+					),
+					'strong' => array(),
+				)
+			);
+			?>
+		</p>
+		<p>
+			<?php esc_html_e( 'The built-in Download ePub reader is active by default, so those actions create an ePub download. Add an e-mail based reader below when you want wireless delivery to a device.', 'send-to-e-reader' ); ?>
+		</p>
+	</div>
+<?php endif; ?>
+
 <form method="post">
 	<?php wp_nonce_field( $args['nonce_value'] ); ?>
 	<table class="reader-table form-table">
@@ -115,7 +143,7 @@ $save_changes = __( 'Save Changes', 'send-to-e-reader' );
 		<?php
 		echo wp_kses(
 			// translators: %s: URL to the Friends Plugin page on WordPress.org.
-			sprintf( __( 'The Friends plugin is all about connecting with friends and news. Learn more on its <a href=%s>plugin page on WordPress.org</a>.', 'send-to-e-reader' ), '"https://wordpress.org/plugins/friends" target="_blank" rel="noopener noreferrer"' ),
+			sprintf( __( 'This plugin also integrates with the Friends plugin for sending friend and feed posts to your e-reader. Learn more on the Friends <a href=%s>plugin page on WordPress.org</a>.', 'send-to-e-reader' ), '"https://wordpress.org/plugins/friends" target="_blank" rel="noopener noreferrer"' ),
 			array(
 				'a' => array(
 					'href'   => array(),

--- a/templates/admin/configure-ereaders.php
+++ b/templates/admin/configure-ereaders.php
@@ -11,35 +11,29 @@ $save_changes = __( 'Save Changes', 'send-to-e-reader' );
 
 ?>
 <?php if ( $args['display_about_friends'] ) : ?>
-	<div class="notice notice-info inline">
-		<p>
-			<strong><?php esc_html_e( 'Using Send to E-Reader without Friends', 'send-to-e-reader' ); ?></strong>
-		</p>
-		<p>
-			<?php
-			echo wp_kses(
-				sprintf(
-					// translators: %s: URL to the WordPress Posts admin page.
-					__( 'Open the <a href="%s">Posts</a> screen, select one or more posts, and choose <strong>Send to E-Reader</strong> from the Bulk actions menu. You can also use the <strong>Send to E-Reader</strong> row action on an individual post.', 'send-to-e-reader' ),
-					esc_url( admin_url( 'edit.php' ) )
+	<h2><?php esc_html_e( 'How to send posts', 'send-to-e-reader' ); ?></h2>
+	<p>
+		<?php
+		echo wp_kses(
+			sprintf(
+				// translators: %s: URL to the WordPress Posts admin page.
+				__( 'Use <strong>Send to E-Reader</strong> on the <a href="%s">Posts</a> screen for a single post, or select several posts and run <strong>Bulk actions > Send to E-Reader</strong>. The default <strong>Download ePub</strong> reader creates an ePub download.', 'send-to-e-reader' ),
+				esc_url( admin_url( 'edit.php' ) )
+			),
+			array(
+				'a'      => array(
+					'href' => array(),
 				),
-				array(
-					'a'      => array(
-						'href' => array(),
-					),
-					'strong' => array(),
-				)
-			);
-			?>
-		</p>
-		<p>
-			<?php esc_html_e( 'The built-in Download ePub reader is active by default, so those actions create an ePub download. Add an e-mail based reader below when you want wireless delivery to a device.', 'send-to-e-reader' ); ?>
-		</p>
-	</div>
+				'strong' => array(),
+			)
+		);
+		?>
+	</p>
 <?php endif; ?>
 
 <form method="post">
 	<?php wp_nonce_field( $args['nonce_value'] ); ?>
+	<h2><?php esc_html_e( 'Delivery options', 'send-to-e-reader' ); ?></h2>
 	<table class="reader-table form-table">
 		<thead>
 			<tr>
@@ -93,15 +87,10 @@ $save_changes = __( 'Save Changes', 'send-to-e-reader' );
 	<?php endif; ?>
 	<p class="description">
 		<?php
-		echo esc_html__( 'Some E-Readers offer wireless delivery via an e-mail address which you\'ll first need to create.', 'send-to-e-reader' );
-		?>
-	</p>
-	<p class="description">
-		<?php
 		echo wp_kses(
 			sprintf(
 				// translators: %1$s and %2$s are URLs.
-				__( 'Examples include Kindle (@free.kindle.com, <a href="%1$s">Instructions</a>) or Pocketbook (@pbsync.com, <a href="%2$s">Instructions</a>).', 'send-to-e-reader' ),
+				__( 'For wireless delivery, add an e-mail based reader after creating its device address. Kindle (<a href="%1$s">instructions</a>) and Pocketbook (<a href="%2$s">instructions</a>) are common examples; the plugin sends an ePub file as an attachment.', 'send-to-e-reader' ),
 				'https://help.fivefilters.org/push-to-kindle/email-address.html" target="_blank" rel="noopener noreferrer',
 				'https://sync.pocketbook-int.com/files/s2pb_info_en.pdf" target="_blank" rel="noopener noreferrer'
 			),
@@ -126,48 +115,38 @@ $save_changes = __( 'Save Changes', 'send-to-e-reader' );
 
 		?>
 	</p>
-	<p class="description">
-		<?php
-		esc_html_e( 'Theoretically you can enter any e-mail address.', 'send-to-e-reader' );
-		echo ' ';
-		esc_html_e( 'By default the plugin will send an e-mail with an ePub file attached.', 'send-to-e-reader' );
-		?>
-		</p>
 	<p class="submit">
 		<input type="submit" id="submit" class="button button-primary" value="<?php echo esc_html( $save_changes ); ?>">
 	</p>
 </form>
 
-<?php if ( $args['display_about_friends'] ) : ?>
-	<p>
-		<?php
-		echo wp_kses(
-			// translators: %s: URL to the Friends Plugin page on WordPress.org.
-			sprintf( __( 'This plugin also integrates with the Friends plugin for sending friend and feed posts to your e-reader. Learn more on the Friends <a href=%s>plugin page on WordPress.org</a>.', 'send-to-e-reader' ), '"https://wordpress.org/plugins/friends" target="_blank" rel="noopener noreferrer"' ),
-			array(
-				'a' => array(
-					'href'   => array(),
-					'rel'    => array(),
-					'target' => array(),
-				),
-			)
-		);
-		?>
-	</p>
-<?php endif; ?>
-<p>
+<p class="description">
 <?php
-echo wp_kses(
-	// translators: %s: URL to the Embed library.
-	sprintf( __( 'This plugin is largely powered by the open source project <a href=%s>PHPePub</a>.', 'send-to-e-reader' ), '"https://github.com/Grandt/PHPePub" target="_blank" rel="noopener noreferrer"' ),
-	array(
-		'a' => array(
-			'href'   => array(),
-			'rel'    => array(),
-			'target' => array(),
-		),
-	)
-);
+if ( $args['display_about_friends'] ) {
+	echo wp_kses(
+		// translators: %1$s: URL to the Friends Plugin page on WordPress.org, %2$s: URL to the PHPePub library.
+		sprintf( __( 'Optional: integrate with the Friends plugin for friend and feed posts (<a href=%1$s>learn more</a>). Powered by <a href=%2$s>PHPePub</a>.', 'send-to-e-reader' ), 'https://wordpress.org/plugins/friends" target="_blank" rel="noopener noreferrer', 'https://github.com/Grandt/PHPePub" target="_blank" rel="noopener noreferrer' ),
+		array(
+			'a' => array(
+				'href'   => array(),
+				'rel'    => array(),
+				'target' => array(),
+			),
+		)
+	);
+} else {
+	echo wp_kses(
+		// translators: %s: URL to the PHPePub library.
+		sprintf( __( 'Powered by <a href=%s>PHPePub</a>.', 'send-to-e-reader' ), 'https://github.com/Grandt/PHPePub" target="_blank" rel="noopener noreferrer' ),
+		array(
+			'a' => array(
+				'href'   => array(),
+				'rel'    => array(),
+				'target' => array(),
+			),
+		)
+	);
+}
 ?>
 </p>
 <?php

--- a/templates/admin/edit-notifications-ereader.php
+++ b/templates/admin/edit-notifications-ereader.php
@@ -18,7 +18,7 @@
 					sprintf(
 						// translators: %s is an URL.
 						__( 'No E-Reader available that supports sending. Go to the <a href=%s>Send to E-Reader settings</a> to add one.', 'send-to-e-reader' ),
-						'"' . self_admin_url( 'admin.php?page=send-to-e-reader' ) . '"'
+						'"' . self_admin_url( 'admin.php?page=send-to-e-reader-ereaders' ) . '"'
 					),
 					array( 'a' => array( 'href' => array() ) )
 				);


### PR DESCRIPTION

<img width="2074" height="842" alt="Screenshot 2026-07-09 at 13 19 05" src="https://github.com/user-attachments/assets/0b562bf8-4d85-4172-a326-987c7a20aa43" />

## Summary
- add standalone-mode guidance to the E-Readers admin page
- explain where to find the Posts bulk action and row action
- clarify that Download ePub is active by default for standalone use

## Testing
- php -l templates/admin/configure-ereaders.php

Notes:
- composer check-cs -- templates/admin/configure-ereaders.php could not run because the configured WordPress PHPCS sniffs are not registered locally.
- composer test -- --filter Test_Send_To_E_Reader currently fails during Send_To_E_Reader construction at includes/class-send-to-e-reader.php:158, before reaching this template change.

<!-- playground-link:start -->
## WordPress Playground

Test this PR in WordPress Playground:

https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/akirk/send-to-e-reader/refs/heads/dist/pr-28/blueprint.json

The linked blueprint loads the generated `dist/pr-28` branch, including Composer dependencies.
<!-- playground-link:end -->