### PR TITLE
Reuse Static Archive HTML for EPUB exports

### DIFF
--- a/includes/class-e-reader.php
+++ b/includes/class-e-reader.php
@@ -126,7 +126,7 @@ abstract class E_Reader {
 			)
 		);
 
-		echo wp_kses_post( $post->post_content );
+		echo wp_kses_post( apply_filters( 'send_to_e_reader_post_content', $post->post_content, $post, $format ) );
 
 		self::get_template_loader()->get_template_part(
 			$format . '/footer',

--- a/includes/class-send-to-e-reader.php
+++ b/includes/class-send-to-e-reader.php
@@ -209,6 +209,7 @@ class Send_To_E_Reader {
 		add_filter( 'template_include', array( $this, 'download_via_url' ) );
 		add_action( 'admin_init', array( $this, 'admin_init' ) );
 		add_filter( 'send_to_e_reader_ebook_author', array( $this, 'filter_ebook_author' ), 10, 2 );
+		add_filter( 'send_to_e_reader_post_content', array( $this, 'filter_static_archive_post_content' ), 10, 3 );
 
 		// Hook into post-collection article notes to identify sent articles.
 		add_filter( 'post_collection_article_queued_meta_query', array( $this, 'filter_article_queued_meta_query' ) );
@@ -260,6 +261,32 @@ class Send_To_E_Reader {
 		}
 
 		return $author;
+	}
+
+	/**
+	 * Use structured Static Archive HTML when exporting supported post types.
+	 *
+	 * @param string   $content Current post content.
+	 * @param \WP_Post $post    Post being exported.
+	 * @param string   $format  Export format.
+	 * @return string Filtered post content.
+	 */
+	public function filter_static_archive_post_content( $content, \WP_Post $post, $format ) {
+		if ( 'epub' !== $format || ! isset( $post->post_type ) ) {
+			return $content;
+		}
+
+		$post_types = apply_filters( 'static_archive_post_types', array() );
+		if ( ! is_array( $post_types ) || ! in_array( $post->post_type, $post_types, true ) ) {
+			return $content;
+		}
+
+		$archive_html = apply_filters( 'static_archive_post_html', '', $post, null );
+		if ( is_string( $archive_html ) && '' !== trim( $archive_html ) ) {
+			return $archive_html;
+		}
+
+		return $content;
 	}
 
 	/**

--- a/tests/Test_Send_To_E_Reader.php
+++ b/tests/Test_Send_To_E_Reader.php
@@ -19,6 +19,9 @@ class Test_Send_To_E_Reader extends TestCase {
 
 	public function tearDown(): void {
 		remove_all_filters( 'friends_override_author_name' );
+		remove_all_filters( 'send_to_e_reader_post_content' );
+		remove_all_filters( 'static_archive_post_types' );
+		remove_all_filters( 'static_archive_post_html' );
 		parent::tearDown();
 	}
 
@@ -113,6 +116,71 @@ class Test_Send_To_E_Reader extends TestCase {
 		$this->assertSame(
 			'Test Author',
 			apply_filters( 'send_to_e_reader_ebook_author', 'Test Author', array( $post ), null, 'Test Author' )
+		);
+	}
+
+	/**
+	 * Test that Static Archive-enabled post types reuse Static Archive HTML.
+	 */
+	public function test_static_archive_post_content_filter_reuses_static_archive_html() {
+		add_filter(
+			'static_archive_post_types',
+			function ( $post_types ) {
+				$post_types[] = 'book-entry';
+				return $post_types;
+			}
+		);
+		add_filter(
+			'static_archive_post_html',
+			function ( $html, $post ) {
+				if ( 'book-entry' === $post->post_type ) {
+					return '<h2>Archive Body</h2><p>Structured export.</p>';
+				}
+
+				return $html;
+			},
+			10,
+			3
+		);
+
+		$send_to_e_reader = new Send_To_E_Reader( null );
+		$post = new \WP_Post();
+		$post->post_type = 'book-entry';
+		$post->post_content = '<p>Plain post body.</p>';
+
+		$this->assertSame(
+			'<h2>Archive Body</h2><p>Structured export.</p>',
+			apply_filters( 'send_to_e_reader_post_content', $post->post_content, $post, 'epub' )
+		);
+	}
+
+	/**
+	 * Test that post types without Static Archive support keep their normal content.
+	 */
+	public function test_static_archive_post_content_filter_ignores_unsupported_post_types() {
+		add_filter(
+			'static_archive_post_types',
+			function () {
+				return array( 'book-entry' );
+			}
+		);
+		add_filter(
+			'static_archive_post_html',
+			function () {
+				return '<h2>Archive Body</h2>';
+			},
+			10,
+			3
+		);
+
+		$send_to_e_reader = new Send_To_E_Reader( null );
+		$post = new \WP_Post();
+		$post->post_type = 'post';
+		$post->post_content = '<p>Article body.</p>';
+
+		$this->assertSame(
+			'<p>Article body.</p>',
+			apply_filters( 'send_to_e_reader_post_content', $post->post_content, $post, 'epub' )
 		);
 	}
 


### PR DESCRIPTION
## Summary
- add a filter around EPUB chapter body content
- reuse Static Archive HTML for post types registered via static_archive_post_types
- cover supported and unsupported post types in tests

## Testing
- vendor/bin/phpunit