### PR TITLE
Update GitHub Actions for Node 24

### DIFF
--- a/.github/workflows/build-dist.yml
+++ b/.github/workflows/build-dist.yml
@@ -28,7 +28,7 @@ jobs:
       DIST_REF: dist/${{ github.ref_name }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -76,7 +76,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Add Playground link to PR description
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         env:
           HEAD_REF: ${{ github.event.pull_request.head.ref }}
         with:
@@ -120,7 +120,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Delete dist branch and remove stale PR links
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         env:
           BRANCH_NAME: ${{ github.event.ref }}
         with:

--- a/.github/workflows/build-dist.yml
+++ b/.github/workflows/build-dist.yml
@@ -28,7 +28,7 @@ jobs:
       DIST_REF: dist/${{ github.ref_name }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -76,7 +76,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Add Playground link to PR description
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           HEAD_REF: ${{ github.event.pull_request.head.ref }}
         with:
@@ -120,7 +120,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Delete dist branch and remove stale PR links
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           BRANCH_NAME: ${{ github.event.ref }}
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Create release directory
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Create release directory
         run: |


### PR DESCRIPTION
Updates CI workflow actions to Node 24-compatible major versions to avoid Node module deprecation warnings.

- actions/checkout to v6
- actions/github-script to v9 where used
- ramsey/composer-install to v4 where used